### PR TITLE
Create ChangeSID.txt

### DIFF
--- a/files/misc/ChangeSID.txt
+++ b/files/misc/ChangeSID.txt
@@ -1,0 +1,13 @@
+@@ title = "Change Trainer SID"
+@@ exit = "Certificate{LANG}"
+
+sid = 00000
+inaccurate_emu = 0
+
+; If you experience issues on emulator, try setting inaccurate_emu to 1.  
+
+@@
+
+sbc r11,pc,{0xD0EE-1+(inaccurate_emu ? 8 : 10)} ?
+movs r12, {sid} ?
+strh r12, [r11, 2]


### PR DESCRIPTION
New code that doesn't require bootstrap to change only SID. Useful for arbitrarily making any frame Shiny, without the need for whole bootstrap setup (or using Sleipnir's character map).

Tested on English (0x40E9 + ARM Bootstrap) and Spanish (0x0599) myself on mGBA 0.10.2 w/ GBA BIOS. Should work on all western languages, will continue testing.