### PR TITLE
Update FRLG PID/TID Corruption code 

### DIFF
--- a/files_frlg/misc/PIDorTIDCorrupt.txt
+++ b/files_frlg/misc/PIDorTIDCorrupt.txt
@@ -10,23 +10,6 @@
 ; LOWER: 0x0FFF4FFFF -> 0x0FFF0FFF
 
 ID = 0xDB           ; 0xDB for OTID, 0xD7 for PID
-CTYPE = 0x00004000  ; 0x40000000 OR 0x00004000 
-
-
-@@
-
-@@ title = "Perform PID or OTID Corruption in Box 3 Slot 1 (Grab ACE)"
-@@ author = "PapaJefe"
-@@ exit = "GrabACEExit"
-
-; Allows for Pomeg-Style PID/OTID Corruption in FRLG.
-; Happens in the same slot as Mail Glitch PID/TID Rewriting.
-; Options to choose the Upper or Lower halves using CTYPE.
-;~EXAMPLES~
-; UPPER: 0x0FFF4FFFF -> 0x4FFF4FFF
-; LOWER: 0x0FFF4FFFF -> 0x0FFF0FFF
-
-ID = 0xDB           ; 0xDB for OTID, 0xD7 for PID
 CTYPE = 0x40000000  ; 0x40000000 OR 0x00004000 
 
 

--- a/files_frlg/misc/PIDorTIDCorrupt.txt
+++ b/files_frlg/misc/PIDorTIDCorrupt.txt
@@ -3,15 +3,17 @@
 @@ exit = "GrabACEExit"
 
 ; Allows for Pomeg-Style PID/OTID Corruption in FRLG.
-; Happens in the same slot as Mail Glitch PID/TID Rewriting.
-; Options to choose the Upper or Lower halves using CTYPE.
-;~EXAMPLES~
-; UPPER: 0x0FFF4FFFF -> 0x4FFF4FFF
-; LOWER: 0x0FFF4FFFF -> 0x0FFF0FFF
+; Default setting is a Pomeg Glitch PID corruption.
+;
+; Fast Double Corruption can be performed by changing ID to 0xDB 
+; for an OTID Corruption and executing the code immediately
+; without viewing Box 3 Slot 1.
+;
+; Advanced users can change CTYPE to corrupt PID/OTID in ways not possible 
+; using the Pomeg Glitch. Will likely need to Double Corrupt to avoid Bad Eggs.
 
-ID = 0xDB           ; 0xDB for OTID, 0xD7 for PID
+ID = 0xD7           ; 0xDB for OTID, 0xD7 for PID
 CTYPE = 0x40000000  ; 0x40000000 OR 0x00004000 
-
 
 @@
 

--- a/files_frlg/misc/PIDorTIDCorrupt.txt
+++ b/files_frlg/misc/PIDorTIDCorrupt.txt
@@ -15,10 +15,28 @@ CTYPE = 0x00004000  ; 0x40000000 OR 0x00004000
 
 @@
 
+@@ title = "Perform PID or OTID Corruption in Box 3 Slot 1 (Grab ACE)"
+@@ author = "PapaJefe"
+@@ exit = "GrabACEExit"
+
+; Allows for Pomeg-Style PID/OTID Corruption in FRLG.
+; Happens in the same slot as Mail Glitch PID/TID Rewriting.
+; Options to choose the Upper or Lower halves using CTYPE.
+;~EXAMPLES~
+; UPPER: 0x0FFF4FFFF -> 0x4FFF4FFF
+; LOWER: 0x0FFF4FFFF -> 0x0FFF0FFF
+
+ID = 0xDB           ; 0xDB for OTID, 0xD7 for PID
+CTYPE = 0x40000000  ; 0x40000000 OR 0x00004000 
+
+
+@@
+
 sbc r11,pc,0x7160 ? 
 movs r12, 0xE02C ?
-STRH r12,[pc,0x14]
+STRH r12,[pc,0x1C]
 movs r12,{CTYPE|0x30} ?
+0x0000FF00
 bic r0,r12, 0xB0 
 ldr r12,[r11,{ID}]!  ; 0xDB for TID, 0xD7 for PID
 0xEEEEC000


### PR DESCRIPTION
Had a user report a bug with this code, when using corruption types that aren't 0x 4000 0000.

Added manual filler to make the untypeable character still align properly in this case.

Altered the instructions to better suit the standard use case, while still allowing for advanced use.

Tested with 0x 4000 0000 on PID and TID for a successful Pomeg Double Corrupt.
Additionally tested 0x 0000 4000 for a successful PID-Lo and TID-Lo Double Corrupt.