### PR TITLE
Add 'Get any item' code from Sleipnir17's pastebin

### DIFF
--- a/files_frlg/misc/GetAnyItem.txt
+++ b/files_frlg/misc/GetAnyItem.txt
@@ -1,0 +1,16 @@
+@@ title = "Get any item (grab ACE)"
+@@ author = "Sleipnir"
+@@ exit = "GrabACEExit"
+
+inaccurate_emu = !!0 %% Set to 1 if you are using an emulator < mgba 0.9
+large_amount = !!0 %% Set to 0 for 999 items, 1 for 65535 items
+item_index ? = 1 @input:item
+
+@@
+
+SBC r12, pc, #{inaccurate_emu ? 0xEE : 0xEC}
+SBC r12, r12, #0xBE00
+MOVS r11, #{large_amount ? 0xFFFFFFFF : 0x3E7} ?
+STRH r11, [r12, #0xC6] %% Store amount
+MOVS r11, #{item_index & 0xFFFF} ?
+STRH r11, [r12, #0xC4] %% Store item index


### PR DESCRIPTION
This pull request contains an adaptation of Sleipnir17's 'Get any item' code for the CodeGenerator. Though I am not sure how to handle this section of the original code:
```
  movs r11, FF                 E3B0B0FF  %%  R11=FF
  adc r11,r11, 2E8             E2ABBFBA  %%  R11=R11+2E8=3E7
  -filler-                     BFBFFF00
  mvn? r11, 0                  *3E0B000  %%  R11=not0=FFFFFFFF  * = E for 65535; B for 999
  -filler-                     BFFF0000
  strh r11 [r12, C6]           E1CCBCB6  %%  Store amount
```
Which allows users to select between two different item quantities.
It should work for all non-Japanese languages.