### PR TITLE
Fix link to exit code setup for hidden power egg code (FRLG)

### DIFF
--- a/files_frlg/pkmn/HiddenPowerEgg.txt
+++ b/files_frlg/pkmn/HiddenPowerEgg.txt
@@ -4,7 +4,7 @@
 
 ; This code requires the FRLG Exit Code bootstrap to work.
 ; It requires a single code and can be found here:
-; https://github.com/it-is-final/PokeG3ACE/blob/main/ace_notes/ExitCodes/FRLG_GrabACE_ShortExit.md#explanation
+; https://github.com/it-is-final/PokeG3ACE/blob/main/ace_notes/ExitCodes/FRLG_GrabACE_ShortExit.md
 ;
 ; This code will create an Egg with the species of your choice in Box 10 Slot 2.
 ; You can select custom IVs to have any Hidden Power Type.

--- a/files_frlg/pkmn/HiddenPowerEgg.txt
+++ b/files_frlg/pkmn/HiddenPowerEgg.txt
@@ -2,8 +2,8 @@
 @@ author = "PapaJefe & it_is_final"
 @@ exit = "Bootstrapped"
 
-; This code requires the FRLG Exit Code bootstrap to work.
-; It requires a single code and can be found here:
+; This code requires a Box 14 exit code for grab ACE.
+; It can be found here:
 ; https://github.com/it-is-final/PokeG3ACE/blob/main/ace_notes/ExitCodes/FRLG_GrabACE_ShortExit.md
 ;
 ; This code will create an Egg with the species of your choice in Box 10 Slot 2.


### PR DESCRIPTION
**DISCLAIMER: I wrote the guide being referred to in the link**
I noticed that the link to the bootstrap setup guide was slightly wrong so I made this pull request.

Should I also change the description from a 'bootstrap' to setting up a box 14 name since the 'bootstrap' linked there is more like a code to write the grab ACE exit to Box 14's name to get more space. Or a 'short exit' if you say.