### PR TITLE
Set hasSpecies flag for Create Pokémon from nothing (without exit code bootstrap)

### DIFF
--- a/files/pkmn/PokemonFromNothingNoBootstrap.txt
+++ b/files/pkmn/PokemonFromNothingNoBootstrap.txt
@@ -6,12 +6,13 @@ species = 0xFF     ; Please set the species you want (it should not be 0)       
 inaccurate_emu = 0 ; Set to 1 if you are using an emulator < mgba 0.9
 
 ; The Box 10 Slot 19 must be empty. A pokemon will appear there after execution of the code.
-; NOTE: The Pokemon created with this method will disappear if moved using the group selection.
 
 @@
 
 sbc r11, r15, #0x2940          ; r11 = &Box10Slot19 + 9
-
+movs r12, #0xE200
+bic r12, r12, #0xFF000 ; r12 = 200, hasSpecies flag set
+strh r12, [r11, #{10 + (inaccurate_emu ? 2 : 0)}]!
 mov r12, {species & 0xFFFF} ?
-strh r12, [r11, {28-(inaccurate_emu?7:9)}]!
-strh r12, [r11, 4]!
+strh r12, [r11, #10]
+strh r12, [r11, #14]


### PR DESCRIPTION
With the information that all 16-bit numbers can be moved into a register in 4 instructions or less, I have modified the 'Create Pokémon from nothing (without exit code bootstrap)' code to allow creating a species from nothing with its hasSpecies flag set without needing an exit code bootstrap.

However I will be leaving this on draft as I have no idea what to do with the already existing bootstrapped version.