### PR TITLE
Updated link to box 14 exit

### DIFF
--- a/files_frlg/misc/ChangeTrainerNameBootstrapped.txt
+++ b/files_frlg/misc/ChangeTrainerNameBootstrapped.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://github.com/it-is-final/PokeG3ACE/blob/main/ace_notes/ExitCodes/FRLG_GrabACE_ShortExit.md
+; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 
 

--- a/files_frlg/misc/EnableTutors.txt
+++ b/files_frlg/misc/EnableTutors.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://github.com/it-is-final/PokeG3ACE/blob/main/ace_notes/ExitCodes/FRLG_GrabACE_ShortExit.md
+; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; After executing, all single-use Move Tutors will be usable again.
 ; It doesn't matter whether they have been used before or not.

--- a/files_frlg/pkmn/FatefulMew.txt
+++ b/files_frlg/pkmn/FatefulMew.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://github.com/it-is-final/PokeG3ACE/blob/main/ace_notes/ExitCodes/FRLG_GrabACE_ShortExit.md   
+; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to far right Bookshelf.

--- a/files_frlg/pkmn/FatefulMew_FR_ENG.txt
+++ b/files_frlg/pkmn/FatefulMew_FR_ENG.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://github.com/it-is-final/PokeG3ACE/blob/main/ace_notes/ExitCodes/FRLG_GrabACE_ShortExit.md   
+; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/FatefulMew_FR_FRA.txt
+++ b/files_frlg/pkmn/FatefulMew_FR_FRA.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://github.com/it-is-final/PokeG3ACE/blob/main/ace_notes/ExitCodes/FRLG_GrabACE_ShortExit.md   
+; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/FatefulMew_FR_GER.txt
+++ b/files_frlg/pkmn/FatefulMew_FR_GER.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://github.com/it-is-final/PokeG3ACE/blob/main/ace_notes/ExitCodes/FRLG_GrabACE_ShortExit.md   
+; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/FatefulMew_FR_ITA.txt
+++ b/files_frlg/pkmn/FatefulMew_FR_ITA.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://github.com/it-is-final/PokeG3ACE/blob/main/ace_notes/ExitCodes/FRLG_GrabACE_ShortExit.md   
+; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/FatefulMew_FR_Rev1_ENG.txt
+++ b/files_frlg/pkmn/FatefulMew_FR_Rev1_ENG.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://github.com/it-is-final/PokeG3ACE/blob/main/ace_notes/ExitCodes/FRLG_GrabACE_ShortExit.md   
+; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/FatefulMew_FR_SPA.txt
+++ b/files_frlg/pkmn/FatefulMew_FR_SPA.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://github.com/it-is-final/PokeG3ACE/blob/main/ace_notes/ExitCodes/FRLG_GrabACE_ShortExit.md   
+; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/FatefulMew_LG_ENG.txt
+++ b/files_frlg/pkmn/FatefulMew_LG_ENG.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://github.com/it-is-final/PokeG3ACE/blob/main/ace_notes/ExitCodes/FRLG_GrabACE_ShortExit.md   
+; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/FatefulMew_LG_FRA.txt
+++ b/files_frlg/pkmn/FatefulMew_LG_FRA.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://github.com/it-is-final/PokeG3ACE/blob/main/ace_notes/ExitCodes/FRLG_GrabACE_ShortExit.md   
+; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/FatefulMew_LG_GER.txt
+++ b/files_frlg/pkmn/FatefulMew_LG_GER.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://github.com/it-is-final/PokeG3ACE/blob/main/ace_notes/ExitCodes/FRLG_GrabACE_ShortExit.md   
+; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/FatefulMew_LG_ITA.txt
+++ b/files_frlg/pkmn/FatefulMew_LG_ITA.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://github.com/it-is-final/PokeG3ACE/blob/main/ace_notes/ExitCodes/FRLG_GrabACE_ShortExit.md   
+; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/FatefulMew_LG_Rev1_ENG.txt
+++ b/files_frlg/pkmn/FatefulMew_LG_Rev1_ENG.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://github.com/it-is-final/PokeG3ACE/blob/main/ace_notes/ExitCodes/FRLG_GrabACE_ShortExit.md   
+; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/FatefulMew_LG_SPA.txt
+++ b/files_frlg/pkmn/FatefulMew_LG_SPA.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://github.com/it-is-final/PokeG3ACE/blob/main/ace_notes/ExitCodes/FRLG_GrabACE_ShortExit.md   
+; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/HiddenPowerEgg.txt
+++ b/files_frlg/pkmn/HiddenPowerEgg.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://github.com/it-is-final/PokeG3ACE/blob/main/ace_notes/ExitCodes/FRLG_GrabACE_ShortExit.md
+; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 ;
 ; This code will create an Egg with the species of your choice in Box 10 Slot 2.
 ; Make sure Box 10 Slot 2 is empty beforehand.

--- a/files_frlg/rng/SeedChangeAndWarpBootstrapped.txt
+++ b/files_frlg/rng/SeedChangeAndWarpBootstrapped.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://github.com/it-is-final/PokeG3ACE/blob/main/ace_notes/ExitCodes/FRLG_GrabACE_ShortExit.md
+; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ;this code will set PRNG to the desired seed when executed. Talk to the NPC you set in the map to warp afterwards. Best ran in the daycare
 


### PR DESCRIPTION
As the Box 14 exit guide is now located in a different location, I have updated all of the references I can find in this pull request. Though I am also open to the idea of including this in the footer of the CodeGenerator (would need a separate pull request) alongside Sleipnir17's short exit guide.