### PR TITLE
Create codes for reading hidden Pokémon stats via TID

### DIFF
--- a/files_frlg/pkmn/ReadContestStats.txt
+++ b/files_frlg/pkmn/ReadContestStats.txt
@@ -1,0 +1,45 @@
+@@ title = "Read contest stats field"
+@@ author = "final"
+@@ exit = "GrabACEExit"
+
+// Place the Pokémon to be read in Box 10, Slot 19
+//
+// This code modifies your trainer ID!
+// Note down your current TID to restore afterwards before proceeding
+// or save now, and reset after performing the process.
+//
+// This code must be executed twice
+// - The first execution should have `field` set to 0
+// - The second execution should have `field` set to 1
+// - The third execution should have `field` set to 2
+//
+// Note down your new trainer ID after each execution
+
+inaccurate_emu = 0
+field = 0
+
+pid = 0x0
+
+// Do not touch the parameters below!
+
+pmod = pid % 24
+ev_substructure_position = \
+    pmod == 12 | pmod == 13 | pmod == 14 | pmod == 15 | \
+    pmod == 16 | pmod == 17 ? 0 : \
+    pmod == 2  | pmod == 3  | pmod == 8  | pmod == 9  | \
+    pmod == 22 | pmod == 23 ? 1 : \
+    pmod == 0  | pmod == 5  | pmod == 6  | pmod == 11 | \
+    pmod == 19 | pmod == 21 ? 2 : 3
+ev_offset = 0xC * ev_substructure_position
+
+@@
+
+SBC     r11, pc, #0xD100        ; r11 = &TID - 0x3?
+SBC     r12, pc, #0x2980        ; r12 = &Box 10, Slot 19 - 0x3?
+BIC     r12, #0xFC000003        ; Word-align address in r12
+LDRH    r12, [r12, #{\
+    (!!inaccurate_emu ? 0x38 : 0x34) \
+    + (0x20 + ev_offset + 6) \
+    + (2 * field) \
+}]
+STRH    r12, [r11, #{!!inaccurate_emu ? 0x34 : 0x32}] ; Store in TID

--- a/files_frlg/pkmn/ReadEvs.txt
+++ b/files_frlg/pkmn/ReadEvs.txt
@@ -1,0 +1,45 @@
+@@ title = "Read EVs field"
+@@ author = "final"
+@@ exit = "GrabACEExit"
+
+// Place the Pokémon to be read in Box 10, Slot 19
+//
+// This code modifies your trainer ID!
+// Note down your current TID to restore afterwards before proceeding
+// or save now, and reset after performing the process.
+//
+// This code must be executed three times
+// - The first execution should have `evs` set to 0
+// - The second execution should have `evs` set to 1
+// - The third execution should have `evs` set to 2
+//
+// Note down your new trainer ID after each execution
+
+inaccurate_emu = 0
+evs = 0
+
+pid = 0x0
+
+// Do not touch the parameters below!
+
+pmod = pid % 24
+ev_substructure_position = \
+    pmod == 12 | pmod == 13 | pmod == 14 | pmod == 15 | \
+    pmod == 16 | pmod == 17 ? 0 : \
+    pmod == 2  | pmod == 3  | pmod == 8  | pmod == 9  | \
+    pmod == 22 | pmod == 23 ? 1 : \
+    pmod == 0  | pmod == 5  | pmod == 6  | pmod == 11 | \
+    pmod == 19 | pmod == 21 ? 2 : 3
+ev_offset = 0xC * ev_substructure_position
+
+@@
+
+SBC     r11, pc, #0xD100        ; r11 = &TID - 0x3?
+SBC     r12, pc, #0x2980        ; r12 = &Box 10, Slot 19 - 0x3?
+BIC     r12, #0xFC000003        ; Word-align address in r12
+LDRH    r12, [r12, #{\
+    (!!inaccurate_emu ? 0x38 : 0x34) \
+    + (0x20 + ev_offset) \
+    + (2 * evs) \
+}]
+STRH    r12, [r11, #{!!inaccurate_emu ? 0x34 : 0x32}] ; Store in TID

--- a/files_frlg/pkmn/ReadIvea.txt
+++ b/files_frlg/pkmn/ReadIvea.txt
@@ -1,0 +1,47 @@
+@@ title = "Read IVEA field"
+@@ author = "final"
+@@ exit = "GrabACEExit"
+
+// Place the Pokémon to be read in Box 10, Slot 19
+//
+// This code modifies your trainer ID!
+// Note down your current TID to restore afterwards before proceeding
+// or save now, and reset after performing the process.
+//
+// This code must be executed twice
+// - The first execution should have `upper` set to 0
+// - The second execution should have `upper` set to 1
+//
+// Note down your new trainer ID after each execution
+//
+// current_encoded_ivea can be calculated with the below formula
+// current_encoded_ivea = (TID_1) + (TID_2 * 65536)
+
+inaccurate_emu = 0
+upper = 0
+
+pid = 0x0
+
+// Do not touch the parameters below!
+
+pmod = pid % 24
+misc_substructure_position = \
+    pmod == 18 | pmod == 19 | pmod == 20 | pmod == 21 | \
+    pmod == 22 | pmod == 23 ? 0 : \
+    pmod == 4  | pmod == 5  | pmod == 10 | pmod == 11 | \
+    pmod == 16 | pmod == 17 ? 1 : \
+    pmod == 1  | pmod == 3  | pmod == 7  | pmod == 9  | \
+    pmod == 13 | pmod == 15 ? 2 : 3
+misc_offset = 0xC * misc_substructure_position
+
+@@
+
+SBC     r11, pc, #0xD100        ; r11 = &TID - 0x3?
+SBC     r12, pc, #0x2980        ; r12 = &Box 10, Slot 19 - 0x3?
+BIC     r12, #0xFC000003        ; Word-align address in r12
+LDRH    r12, [r12, #{\
+    (!!inaccurate_emu ? 0x38 : 0x34) \
+    + (0x20 + misc_offset + 4) \
+    + (!!upper ? 0x2 : 0x0) \
+}]
+STRH    r12, [r11, #{!!inaccurate_emu ? 0x34 : 0x32}] ; Store in TID

--- a/files_frlg/pkmn/ReadPid.txt
+++ b/files_frlg/pkmn/ReadPid.txt
@@ -1,0 +1,34 @@
+@@ title = "Read PID"
+@@ author = "final"
+@@ exit = "GrabACEExit"
+
+// Place the Pokémon to be read in Box 10, Slot 19
+//
+// This code modifies your trainer ID!
+// Note down your current TID to restore afterwards before proceeding
+// or save now, and reset after performing the process.
+//
+// This code must be executed twice
+// - The first execution should have `upper` set to 0
+// - The second execution should have `upper` set to 1
+//
+// Note down your new trainer ID after each execution
+//
+// PID can be calculated with the below formula
+// PID = (TID_1) + (TID_2 * 65536)
+
+inaccurate_emu = 0
+upper = 0
+
+// Do not touch the parameters below!
+
+@@
+
+SBC     r11, pc, #0xD100        ; r11 = &TID - 0x3?
+SBC     r12, pc, #0x2980        ; r12 = &Box 10, Slot 19 - 0x3?
+BIC     r12, #0xFC000003        ; Word-align address in r12
+LDRH    r12, [r12, #{\
+    (!!inaccurate_emu ? 0x38 : 0x34) \
+    + (!!upper ? 0x2 : 0x0) \
+}]
+STRH    r12, [r11, #{!!inaccurate_emu ? 0x34 : 0x32}] ; Store in TID

--- a/files_frlg/pkmn/ReadPkrus.txt
+++ b/files_frlg/pkmn/ReadPkrus.txt
@@ -1,0 +1,47 @@
+@@ title = "Read Pokérus field"
+@@ author = "final"
+@@ exit = "GrabACEExit"
+
+// Place the Pokémon to be read in Box 10, Slot 19
+//
+// This code modifies your trainer ID!
+// Note down your current TID to restore afterwards before proceeding
+// or save now, and reset after performing the process.
+//
+// This code must be executed twice
+// - The first execution should have `upper` set to 0
+// - The second execution should have `upper` set to 1
+//
+// Note down your new trainer ID after each execution
+//
+// current_encoded_pkrus can be calculated with the below formula
+// current_encoded_pkrus = (TID_1) + (TID_2 * 65536)
+
+inaccurate_emu = 0
+upper = 0
+
+pid = 0x0
+
+// Do not touch the parameters below!
+
+pmod = pid % 24
+misc_substructure_position = \
+    pmod == 18 | pmod == 19 | pmod == 20 | pmod == 21 | \
+    pmod == 22 | pmod == 23 ? 0 : \
+    pmod == 4  | pmod == 5  | pmod == 10 | pmod == 11 | \
+    pmod == 16 | pmod == 17 ? 1 : \
+    pmod == 1  | pmod == 3  | pmod == 7  | pmod == 9  | \
+    pmod == 13 | pmod == 15 ? 2 : 3
+misc_offset = 0xC * misc_substructure_position
+
+@@
+
+SBC     r11, pc, #0xD100        ; r11 = &TID - 0x3?
+SBC     r12, pc, #0x2980        ; r12 = &Box 10, Slot 19 - 0x3?
+BIC     r12, #0xFC000003        ; Word-align address in r12
+LDRH    r12, [r12, #{\
+    (!!inaccurate_emu ? 0x38 : 0x34) \
+    + (0x20 + misc_offset) \
+    + (!!upper ? 0x2 : 0x0) \
+}]
+STRH    r12, [r11, #{!!inaccurate_emu ? 0x34 : 0x32}] ; Store in TID

--- a/files_frlg/pkmn/ReadRibbonsAndObedience.txt
+++ b/files_frlg/pkmn/ReadRibbonsAndObedience.txt
@@ -1,0 +1,49 @@
+@@ title = "Read Pokérus field"
+@@ author = "final"
+@@ exit = "GrabACEExit"
+
+// Place the Pokémon to be read in Box 10, Slot 19
+//
+// This code modifies your trainer ID!
+// Note down your current TID to restore afterwards before proceeding
+// or save now, and reset after performing the process.
+//
+// This code must be executed twice
+// - The first execution should have `upper` set to 0
+// - The second execution should have `upper` set to 1
+//
+// Note down your new trainer ID after each execution
+//
+// current_encoded_ribbons can be calculated with the below formula:
+// current_encoded_ribbons = (TID_1) + (TID_2 * 65536) % 2147483648
+// current_encoded_obedience can be calculated with the below formula:
+// current_encoded_obedience = (TID_2) / 32768
+
+inaccurate_emu = 0
+upper = 0
+
+pid = 0x0
+
+// Do not touch the parameters below!
+
+pmod = pid % 24
+misc_substructure_position = \
+    pmod == 18 | pmod == 19 | pmod == 20 | pmod == 21 | \
+    pmod == 22 | pmod == 23 ? 0 : \
+    pmod == 4  | pmod == 5  | pmod == 10 | pmod == 11 | \
+    pmod == 16 | pmod == 17 ? 1 : \
+    pmod == 1  | pmod == 3  | pmod == 7  | pmod == 9  | \
+    pmod == 13 | pmod == 15 ? 2 : 3
+misc_offset = 0xC * misc_substructure_position
+
+@@
+
+SBC     r11, pc, #0xD100        ; r11 = &TID - 0x3?
+SBC     r12, pc, #0x2980        ; r12 = &Box 10, Slot 19 - 0x3?
+BIC     r12, #0xFC000003        ; Word-align address in r12
+LDRH    r12, [r12, #{\
+    (!!inaccurate_emu ? 0x38 : 0x34) \
+    + (0x20 + misc_offset + 8) \
+    + (!!upper ? 0x2 : 0x0) \
+}]
+STRH    r12, [r11, #{!!inaccurate_emu ? 0x34 : 0x32}] ; Store in TID


### PR DESCRIPTION
This ensures parity between Emerald and FR/LG ACE by porting over codes that only exist in Emerald to FR/LG.

These codes are grab ACE only, and use the TID to store the values at the moment.
However I also noticed in the same repository that papajefe and notblisy also made similar codes that utilised `LDRB`/`STRB` into the stats of party Pokémon (while managing to avoid FR/LG's inability to display stats above 999).

This is a draft pull request as I would still need to add these to list.json (and possibly scrap using the TID and use papajefe and notblisy's tricks).