### PR TITLE
Change it-is-final.github.io links to pomeg-letterbombers.github.io for pokemon-ace-notes

### DIFF
--- a/files_frlg/misc/ChangeTrainerNameBootstrapped.txt
+++ b/files_frlg/misc/ChangeTrainerNameBootstrapped.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 
 

--- a/files_frlg/misc/EnableTutors.txt
+++ b/files_frlg/misc/EnableTutors.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; After executing, all single-use Move Tutors will be usable again.
 ; It doesn't matter whether they have been used before or not.

--- a/files_frlg/pkmn/FatefulMew.txt
+++ b/files_frlg/pkmn/FatefulMew.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to far right Bookshelf.

--- a/files_frlg/pkmn/FatefulMew_FR_ENG.txt
+++ b/files_frlg/pkmn/FatefulMew_FR_ENG.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/FatefulMew_FR_FRA.txt
+++ b/files_frlg/pkmn/FatefulMew_FR_FRA.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/FatefulMew_FR_GER.txt
+++ b/files_frlg/pkmn/FatefulMew_FR_GER.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/FatefulMew_FR_ITA.txt
+++ b/files_frlg/pkmn/FatefulMew_FR_ITA.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/FatefulMew_FR_Rev1_ENG.txt
+++ b/files_frlg/pkmn/FatefulMew_FR_Rev1_ENG.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/FatefulMew_FR_SPA.txt
+++ b/files_frlg/pkmn/FatefulMew_FR_SPA.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/FatefulMew_LG_ENG.txt
+++ b/files_frlg/pkmn/FatefulMew_LG_ENG.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/FatefulMew_LG_FRA.txt
+++ b/files_frlg/pkmn/FatefulMew_LG_FRA.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/FatefulMew_LG_GER.txt
+++ b/files_frlg/pkmn/FatefulMew_LG_GER.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/FatefulMew_LG_ITA.txt
+++ b/files_frlg/pkmn/FatefulMew_LG_ITA.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/FatefulMew_LG_Rev1_ENG.txt
+++ b/files_frlg/pkmn/FatefulMew_LG_Rev1_ENG.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/FatefulMew_LG_SPA.txt
+++ b/files_frlg/pkmn/FatefulMew_LG_SPA.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ; This code must be run at Indigo Plateau
 ; After running, talk to the PokeMart NPC

--- a/files_frlg/pkmn/HiddenPowerEgg.txt
+++ b/files_frlg/pkmn/HiddenPowerEgg.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 ;
 ; This code will create an Egg with the species of your choice in Box 10 Slot 2.
 ; Make sure Box 10 Slot 2 is empty beforehand.

--- a/files_frlg/pkmn/PIDEggFromNothing.txt
+++ b/files_frlg/pkmn/PIDEggFromNothing.txt
@@ -4,7 +4,7 @@
 
 // This code requires a Box 14 exit code for grab ACE.
 // It can be found here:
-// https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+// https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 // Make sure that Box 10, Slot 2 is empty before proceeding with this
 // code.

--- a/files_frlg/pkmn/ReadContestStats.txt
+++ b/files_frlg/pkmn/ReadContestStats.txt
@@ -4,7 +4,7 @@
 
 // This code requires a Box 14 exit code for grab ACE.
 // It can be found here:
-// https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+// https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 // 1.  Place the Pokémon to be read in the 2nd party slot.
 // 2.  Enter that Pokémon’s personality value into the `pid` parameter.

--- a/files_frlg/pkmn/ReadEvs.txt
+++ b/files_frlg/pkmn/ReadEvs.txt
@@ -4,7 +4,7 @@
 
 // This code requires a Box 14 exit code for grab ACE.
 // It can be found here:
-// https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+// https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 // 1.  Place the Pokémon to be read in the 2nd party slot.
 // 2.  Enter that Pokémon’s personality value into the `pid` parameter.

--- a/files_frlg/rng/SeedChangeAndWarpBootstrapped.txt
+++ b/files_frlg/rng/SeedChangeAndWarpBootstrapped.txt
@@ -4,7 +4,7 @@
 
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
-; https://it-is-final.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
 ;this code will set PRNG to the desired seed when executed. Talk to the NPC you set in the map to warp afterwards. Best ran in the daycare
 


### PR DESCRIPTION
I have changed the owner of the underlying GitHub repository for my website, and therefore the GitHub Pages links has changed for the main branch. The reason that these old links were still working is because I have kept a fork of the repo with Actions, and GitHub Pages enabled. However as the fork's gh-pages branch may get desynched from the main repository, I thought it would be worth it now to search and replace all instances of the old domain name (it-is-final.github.io) with (pomeg-letterbombers.github.io).