### PR TITLE
Change Variable Code

### DIFF
--- a/files/list.json
+++ b/files/list.json
@@ -505,5 +505,14 @@
     "spa": "misc/ChangeFlag.txt",
     "ita": "misc/ChangeFlag.txt",
     "cat": ["misc"]
+  },
+  {
+    "name": "Change Variable",
+    "eng": "misc/ChangeVar.txt",
+    "fra": "misc/ChangeVar.txt",
+    "ger": "misc/ChangeVar.txt",
+    "spa": "misc/ChangeVar.txt",
+    "ita": "misc/ChangeVar.txt",
+    "cat": ["misc"]
   }
 ]

--- a/files/misc/ChangeVar.txt
+++ b/files/misc/ChangeVar.txt
@@ -1,0 +1,19 @@
+@@ title = "Change Variable"
+@@ author = "Adrichu00"
+@@ exit = "CertificateFull{LANG}"
+
+; Full list of vars: https://github.com/pret/pokeemerald/blob/master/include/constants/vars.h
+; This code won't work with special variables (0x80XX)
+; It will work just with normal variables (0x40XX)
+var   = 0x00       ; You can use just the lower byte
+value = 0x0000     ; From 0x0000 to 0xFFFF
+inaccurate_emu = 0 ; Set to 1 if you are using an emulator < mgba 0.9
+
+; Do not modify this
+var_offset = (inaccurate_emu? 0xADB8: 0xADBA) - ((var & 0xFF) << 1)
+
+@@
+
+SUB r11, pc, {var_offset} ? ; r11 = &gSaveBlock1Ptr->vars[var]
+MOV r12, {value} ?          ; r12 = value
+STRH r12, [r11]             ; gSaveBlock1Ptr->vars[var] = value

--- a/files_frlg/list.json
+++ b/files_frlg/list.json
@@ -393,5 +393,16 @@
     "ita": "misc/ChangeFlag.txt",
     "game": ["fr", "lg"],
     "cat": ["misc"]
+  },
+  {
+    "name": "Change Variable",
+    "eng1": "misc/ChangeVar.txt",
+    "eng0": "misc/ChangeVar.txt",
+    "fra": "misc/ChangeVar.txt",
+    "ger": "misc/ChangeVar.txt",
+    "spa": "misc/ChangeVar.txt",
+    "ita": "misc/ChangeVar.txt",
+    "game": ["fr", "lg"],
+    "cat": ["misc"]
   }
 ]

--- a/files_frlg/misc/ChangeVar.txt
+++ b/files_frlg/misc/ChangeVar.txt
@@ -1,0 +1,19 @@
+@@ title = "Change Variable"
+@@ author = "Adrichu00"
+@@ exit = "GrabACEExit"
+
+; Full list of vars: https://github.com/pret/pokefirered/blob/master/include/constants/vars.h
+; This code won't work with special variables (0x80XX)
+; It will work just with normal variables (0x40XX)
+var   = 0x00       ; You can use just the lower byte of the var id
+value = 0x0000     ; From 0x0000 to 0xFFFF
+inaccurate_emu = 0 ; Set to 1 if you are using an emulator < mgba 0.9
+
+; Do not modify this
+var_offset = (inaccurate_emu? 0xB134: 0xB136) - ((var & 0xFF) << 1)
+
+@@
+
+SUB r11, pc, {var_offset} ? ; r11 = &gSaveBlock1Ptr->vars[var]
+MOV r12, {value} ?          ; r12 = value
+STRH r12, [r11]             ; gSaveBlock1Ptr->vars[var] = value


### PR DESCRIPTION
## Tested code generation
* `SUB r11, pc, {var_offset} ?` takes at most 3 instructions for any variable on both games
* `MOV r12, {value} ?` takes at most 4 instructions for any 2 byte value

Then, since writing the variable takes one instruction more, we can confirm that all cases (at most, `3 + 4 + 1 = 8` instructions) fit with *CertificateFull* exits (space for 9 instructions) or *GrabACEExit* (space for 12 instructions)