### PR TITLE
Change Flag - Multiple Flags

### DIFF
--- a/files/misc/ChangeFlag.txt
+++ b/files/misc/ChangeFlag.txt
@@ -2,21 +2,40 @@
 @@ author = "Adrichu00 | Final"
 @@ exit = "CertificateShort{LANG}"
 
+
 ; WARNINGS:
 ; * This code modifies r0
 ; * This code needs `BX r0` in box 14's name (`Œ`). You can execute any code
 ;   with the "CertificateFull{LANG}" exit to write it. You can also try to
 ;   compile this code with "CertificateFull{LANG}", but it may not fit
 
+
 ; Full list of flags: https://github.com/pret/pokeemerald/blob/master/include/constants/flags.h
 flag  = 0x000
 value = 0          ; 0 for clear, 1 for set
 inaccurate_emu = 0 ; Set to 1 if you are using an emulator < mgba 0.9
 
+; Multiple Flags
+;   This halfword (2 bytes) will be bitwise ORed with the flag_mask, changing
+;   also those flags. Keep in mind that this value has to be 2-byte-aligned in
+;   memory. Only flags within the same halfword as the target flag can be
+;   modified. Your flag above doesn't need to be added (1 << (flag & 0x0F)).
+;   Setting this parameter to 0 just changes the target flag
+
+multi_flag = 0x0000
+
+; For example:
+;   In order to clear FLAG_DEFEATED_MEW and FLAG_CAUGHT_MEW (flags 0x1C7 and
+;   0x1CA), you can set the parameters to:
+;     flag = 0x1C7
+;     value = 0
+;     multi_flag = 0x0400 ; or 0x0480
+
 
 ; Do not modify these
 flag_offset = (inaccurate_emu? 0xAEE4: 0xAEE6) - ((flag >> 3) & ~0x01)
-flag_mask   = 0x0001 << (flag & 0x0F)
+flag_mask   = (0x0001 << (flag & 0x0F)) | (multi_flag & 0xFFFF)
+
 
 @@
 

--- a/files/misc/ChangeFlag.txt
+++ b/files/misc/ChangeFlag.txt
@@ -2,13 +2,11 @@
 @@ author = "Adrichu00 | Final"
 @@ exit = "CertificateShort{LANG}"
 
-
 ; WARNINGS:
 ; * This code modifies r0
 ; * This code needs `BX r0` in box 14's name (`Œ`). You can execute any code
 ;   with the "CertificateFull{LANG}" exit to write it. You can also try to
 ;   compile this code with "CertificateFull{LANG}", but it may not fit
-
 
 ; Full list of flags: https://github.com/pret/pokeemerald/blob/master/include/constants/flags.h
 flag  = 0x000
@@ -31,11 +29,9 @@ multi_flag = 0x0000
 ;     value = 0
 ;     multi_flag = 0x0400 ; or 0x0480
 
-
 ; Do not modify these
 flag_offset = (inaccurate_emu? 0xAEE4: 0xAEE6) - ((flag >> 3) & ~0x01)
 flag_mask   = (0x0001 << (flag & 0x0F)) | (multi_flag & 0xFFFF)
-
 
 @@
 

--- a/files_frlg/misc/ChangeFlag.txt
+++ b/files_frlg/misc/ChangeFlag.txt
@@ -2,9 +2,7 @@
 @@ author = "Adrichu00 | Final"
 @@ exit = "GrabACEExit"
 
-
 ; WARNING: This code modifies r0
-
 
 ; Full list of flags: https://github.com/pret/pokefirered/blob/master/include/constants/flags.h
 flag  = 0x000
@@ -28,11 +26,9 @@ multi_flag = 0x0000
 ;     value = 0
 ;     multi_flag = 0xE000 ; or 0xF000
 
-
 ; Do not modify these:
 flag_offset = (inaccurate_emu? 0xB254: 0xB256) - ((flag >> 3) & ~0x01)
 flag_mask   = (0x0001 << (flag & 0x0F)) | (multi_flag & 0xFFFF)
-
 
 @@
 

--- a/files_frlg/misc/ChangeFlag.txt
+++ b/files_frlg/misc/ChangeFlag.txt
@@ -2,17 +2,37 @@
 @@ author = "Adrichu00 | Final"
 @@ exit = "GrabACEExit"
 
+
 ; WARNING: This code modifies r0
+
 
 ; Full list of flags: https://github.com/pret/pokefirered/blob/master/include/constants/flags.h
 flag  = 0x000
 value = 0          ; 0 for clear, 1 for set
 inaccurate_emu = 0 ; Set to 1 if you are using an emulator < mgba 0.9
 
+; Multiple Flags
+;   This halfword (2 bytes) will be bitwise ORed with the flag_mask, changing
+;   also those flags. Keep in mind that this value has to be 2-byte-aligned in
+;   memory. Only flags within the same halfword as the target flag can be
+;   modified. Your flag above doesn't need to be added (1 << (flag & 0x0F)).
+;   Setting this parameter to 0 just changes the target flag
+
+multi_flag = 0x0000
+
+; For example:
+;   In order to clear FLAG_FOUGHT_MEWTWO, FLAG_FOUGHT_MOLTRES,
+;   FLAG_FOUGHT_ARTICUNO and FLAG_FOUGHT_ZAPDOS (flags 0x2BC to 0x2BF), you can
+;   set the parameters to:
+;     flag = 0x2BC
+;     value = 0
+;     multi_flag = 0xE000 ; or 0xF000
+
 
 ; Do not modify these:
 flag_offset = (inaccurate_emu? 0xB254: 0xB256) - ((flag >> 3) & ~0x01)
-flag_mask   = 0x0001 << (flag & 0x0F)
+flag_mask   = (0x0001 << (flag & 0x0F)) | (multi_flag & 0xFFFF)
+
 
 @@
 


### PR DESCRIPTION
## Tested code generation
Similar to code *Change Variable* generation tests:
* `SUB r11, pc, {flag_offset} ?` takes at most 3 instructions for any flag on both games
* `MOV r12, {flag_mask} ?` takes at most 4 instructions for any 2 byte value

Then, since the rest of the code takes at most 5 instructions, we can confirm that all cases (at most, `3 + 4 + 5 = 12` instructions) fit with *CertificateShort* exits (space for 13 instructions) or *GrabACEExit* (space for 12 instructions)