### PR TITLE
Change Battle Points Code

### DIFF
--- a/files/list.json
+++ b/files/list.json
@@ -516,7 +516,7 @@
     "cat": ["misc"]
   },
   {
-    "name": "Max Battle Points",
+    "name": "Change Battle Points",
     "eng": "misc/ChangeBPs.txt",
     "fra": "misc/ChangeBPs.txt",
     "ger": "misc/ChangeBPs.txt",

--- a/files/misc/ChangeBPs.txt
+++ b/files/misc/ChangeBPs.txt
@@ -1,15 +1,16 @@
-@@ title = "Increase the amount of Battle Points"
-@@ author = "Sleipnir (ported by Adrichu00)"
+@@ title = "Change Battle Points"
+@@ author = "Sleipnir (adapted by Adrichu00)"
 @@ exit = "CertificateFull{LANG}"
 
-; Note: this code will set the amount of Battle Points to 65535
+; Based on Sleipnir's *Increase the amount of Battle Points* code
 
+value = 0xFFFF
 inaccurate_emu = 0 ; Set to 1 if you are using an emulator < mgba 0.9
 
 @@
 
-; r12 = gSaveBlock2Ptr->frontier.battlePoints
-SBC  r12, pc, 0xC400
-ADC  r12, r12, {inaccurate_emu? 0xE9: 0xE7}
-MVN  r11, 0x00         ; r11 = ~0 = 0xFFFFFFFF
-STRH r11, [r12, 0xD0]  ; Write BPs
+; r11 = gSaveBlock2Ptr->frontier.battlePoints
+SBC  r11, pc, 0xC400
+ADC  r11, r11, {inaccurate_emu? 0xE9: 0xE7}
+MOV  r12, {value & 0xFFFF} ?  ; r12 = value & 0xFFFF
+STRH r12, [r11, 0xD0]         ; Write BPs


### PR DESCRIPTION
Port of Sleipnir's *Increase the amount of Battle Points* code. It's a bit changed in order to write with an aligned address (not required) and to use opcodes without the *S* bit (also not required)

As mentioned in #67,
> `MOV r12, {value} ?` takes at most 4 instructions for any 2 byte value

Therefore, this code will take at most `4 + 3 = 7` instructions and will fit with *CertificateFull* exits (space for 9 instructions)