### PR TITLE
RS codes

### DIFF
--- a/files_rs/list.json
+++ b/files_rs/list.json
@@ -106,6 +106,22 @@
     "cat": ["pkmn","bootstraps"]
   },
   {
+    "name": "Change Pokemon Level",
+    "eng2": "pkmn/ChangeLevel.txt",
+    "eng1": "pkmn/ChangeLevel.txt",
+    "eng0": "pkmn/ChangeLevel.txt",
+    "fra1": "pkmn/ChangeLevel.txt",
+    "fra0": "pkmn/ChangeLevel.txt",
+    "ger1": "pkmn/ChangeLevel.txt",
+    "ger0": "pkmn/ChangeLevel.txt",
+    "spa1": "pkmn/ChangeLevel.txt",
+    "spa0": "pkmn/ChangeLevel.txt",
+    "ita1": "pkmn/ChangeLevel.txt",
+    "ita0": "pkmn/ChangeLevel.txt",
+    "game": ["ruby", "sapp"],
+    "cat": ["pkmn"]
+  },
+  {
     "name": "Return Exit Code Bootstrap",
     "eng2": "bootstraps/ReturnExitCodeBootstrapENG.txt",
     "eng1": "bootstraps/ReturnExitCodeBootstrapENG.txt",

--- a/files_rs/list.json
+++ b/files_rs/list.json
@@ -71,7 +71,23 @@
     "game": ["ruby", "sapp"],
     "cat": ["misc"]
   },
-    {
+  {
+    "name": "Read PID",
+    "eng2": "pkmn/ReadPid.txt",
+    "eng1": "pkmn/ReadPid.txt",
+    "eng0": "pkmn/ReadPid.txt",
+    "fra1": "pkmn/ReadPid.txt",
+    "fra0": "pkmn/ReadPid.txt",
+    "ger1": "pkmn/ReadPid.txt",
+    "ger0": "pkmn/ReadPid.txt",
+    "spa1": "pkmn/ReadPid.txt",
+    "spa0": "pkmn/ReadPid.txt",
+    "ita1": "pkmn/ReadPid.txt",
+    "ita0": "pkmn/ReadPid.txt",
+    "game": ["ruby", "sapp"],
+    "cat": ["pkmn"]
+  },
+  {
     "name": "Create Pokemon species from nothing",
     "eng2": "pkmn/PokemonFromNothing.txt",
     "eng1": "pkmn/PokemonFromNothing.txt",
@@ -107,7 +123,7 @@
     "game": ["ruby", "sapp"],
     "cat": ["bootstraps"]
   },
-    {
+  {
     "name": "Change PRNG seed and teleport",
     "eng2": "rng/SeedChangeAndWarpENG.txt",
     "eng1": "rng/SeedChangeAndWarpENG.txt",

--- a/files_rs/list.json
+++ b/files_rs/list.json
@@ -156,5 +156,21 @@
     "jap1": "rng/SeedChangeAndWarpJP.txt",
     "game": ["ruby", "sapp"],
     "cat": ["rng"]
+  },
+  {
+    "name": "Change full trainer name (legal)",
+    "eng2": "misc/ChangeFullTrainerName.txt",
+    "eng1": "misc/ChangeFullTrainerName.txt",
+    "eng0": "misc/ChangeFullTrainerName.txt",
+    "fra1": "misc/ChangeFullTrainerName.txt",
+    "fra0": "misc/ChangeFullTrainerName.txt",
+    "ger1": "misc/ChangeFullTrainerName.txt",
+    "ger0": "misc/ChangeFullTrainerName.txt",
+    "spa1": "misc/ChangeFullTrainerName.txt",
+    "spa0": "misc/ChangeFullTrainerName.txt",
+    "ita1": "misc/ChangeFullTrainerName.txt",
+    "ita0": "misc/ChangeFullTrainerName.txt",
+    "game": ["ruby", "sapp"],
+    "cat": ["misc"]
   }
 ]

--- a/files_rs/list.json
+++ b/files_rs/list.json
@@ -174,6 +174,22 @@
     "cat": ["misc"]
   },
   {
+    "name": "Change Flag",
+    "eng2": "misc/ChangeFlag.txt",
+    "eng1": "misc/ChangeFlag.txt",
+    "eng0": "misc/ChangeFlag.txt",
+    "fra1": "misc/ChangeFlag.txt",
+    "fra0": "misc/ChangeFlag.txt",
+    "ger1": "misc/ChangeFlag.txt",
+    "ger0": "misc/ChangeFlag.txt",
+    "spa1": "misc/ChangeFlag.txt",
+    "spa0": "misc/ChangeFlag.txt",
+    "ita1": "misc/ChangeFlag.txt",
+    "ita0": "misc/ChangeFlag.txt",
+    "game": ["ruby", "sapp"],
+    "cat": ["misc"]
+  },
+  {
     "name": "Change Variable",
     "eng2": "misc/ChangeVar.txt",
     "eng1": "misc/ChangeVar.txt",

--- a/files_rs/list.json
+++ b/files_rs/list.json
@@ -172,5 +172,21 @@
     "ita0": "misc/ChangeFullTrainerName.txt",
     "game": ["ruby", "sapp"],
     "cat": ["misc"]
+  },
+  {
+    "name": "Change Variable",
+    "eng2": "misc/ChangeVar.txt",
+    "eng1": "misc/ChangeVar.txt",
+    "eng0": "misc/ChangeVar.txt",
+    "fra1": "misc/ChangeVar.txt",
+    "fra0": "misc/ChangeVar.txt",
+    "ger1": "misc/ChangeVar.txt",
+    "ger0": "misc/ChangeVar.txt",
+    "spa1": "misc/ChangeVar.txt",
+    "spa0": "misc/ChangeVar.txt",
+    "ita1": "misc/ChangeVar.txt",
+    "ita0": "misc/ChangeVar.txt",
+    "game": ["ruby", "sapp"],
+    "cat": ["misc"]
   }
 ]

--- a/files_rs/misc/ChangeFlag.txt
+++ b/files_rs/misc/ChangeFlag.txt
@@ -1,0 +1,44 @@
+@@ title = "Change Flag"
+@@ author = "Adrichu00 | final"
+@@ exit = "ReturnToOverworldShort_ENG"
+
+; WARNINGS:
+; * This code modifies r0
+; * This code needs `BX r0` in box 14's name (`Œ`). You can execute any code
+;   with the "ReturnToOverworldFull_ENG" exit to write it. You can also try to
+;   compile this code with "ReturnToOverworldFull_ENG", but it may not fit
+
+; Full list of flags: https://github.com/pret/pokeruby/blob/master/include/constants/flags.h
+flag  = 0x000
+value = 0          ; 0 for clear, 1 for set
+
+; Multiple Flags
+;   This halfword (2 bytes) will be bitwise ORed with the flag_mask, changing
+;   also those flags. Keep in mind that this value has to be 2-byte-aligned in
+;   memory. Only flags within the same halfword as the target flag can be
+;   modified. Your flag above doesn't need to be added (1 << (flag & 0x0F)).
+;   Setting this parameter to 0 just changes the target flag
+
+multi_flag = 0x0000
+
+; For example:
+;   In order to set all badge flags (flags from 0x807 to 0x80E), you can set
+;   the parameters to:
+;     flag = 0x807
+;     value = 1
+;     multi_flag = 0x3F00 ; or 0x3F80
+
+; Do not modify these
+flag_offset = 0x011A98 - ((flag >> 3) & ~0x01)
+flag_mask   = (0x0001 << (flag & 0x0F)) | (multi_flag & 0xFFFF)
+
+@@
+
+; r11 = &gSaveBlock1.flags + ((flag >> 3) & ~0x01)
+SUB  r11, pc, {flag_offset} ?
+MOV  r12, {flag_mask} ?
+BIC  r0, r12, 0x00
+LDRH r12, [r11]                 ; Load Current Value
+BIC  r12, r12, r0
+{value? 0xE0ACC000: 0xB00000FF} ; ADC r12, r12, r0
+STRH r12, [r11]                 ; Store Updated Value

--- a/files_rs/misc/ChangeFlag.txt
+++ b/files_rs/misc/ChangeFlag.txt
@@ -1,12 +1,12 @@
 @@ title = "Change Flag"
 @@ author = "Adrichu00 | final"
-@@ exit = "ReturnToOverworldShort_ENG"
+@@ exit = "ReturnToOverworldShort_{LANGNR}"
 
 ; WARNINGS:
 ; * This code modifies r0
 ; * This code needs `BX r0` in box 14's name (`Œ`). You can execute any code
-;   with the "ReturnToOverworldFull_ENG" exit to write it. You can also try to
-;   compile this code with "ReturnToOverworldFull_ENG", but it may not fit
+;   with the "ReturnToOverworldFull_{LANGNR}" exit to write it. You can also try to
+;   compile this code with "ReturnToOverworldFull_{LANGNR}", but it may not fit
 
 ; Full list of flags: https://github.com/pret/pokeruby/blob/master/include/constants/flags.h
 flag  = 0x000

--- a/files_rs/misc/ChangeFullTrainerName.txt
+++ b/files_rs/misc/ChangeFullTrainerName.txt
@@ -1,6 +1,6 @@
 @@ title = "Change full trainer name (legal)"
 @@ author = "Sleipnir17 (ported by Adrichu00)"
-@@ exit = "ReturnToOverworldFull_{LANG}"
+@@ exit = "ReturnToOverworldFull_{LANGNR}"
 
 ; Write your desired name in BOX 5's name
 ; Don't use the last char slot, leave it empty

--- a/files_rs/misc/ChangeFullTrainerName.txt
+++ b/files_rs/misc/ChangeFullTrainerName.txt
@@ -1,0 +1,25 @@
+@@ title = "Change full trainer name (legal)"
+@@ author = "Sleipnir17 (ported by Adrichu00)"
+@@ exit = "ReturnToOverworldFull_{LANG}"
+
+; Write your desired name in BOX 5's name
+; Don't use the last char slot, leave it empty
+
+; This method can only produce legal names that you would be able to write in a
+; normal case.
+
+@@
+
+; r11 = &gSaveBlock2.playerName - 4
+; SUB r11, 0x1354C ?
+SBC r11, r15, #0x3580
+SBC r11, r11, #0xC9
+SBC r11, r11, #0xFF00
+ADCS r12, pc, 0x0C    ; r12: Pointer to BOX 5 Name (-4)
+0xE9BC00C0            ; (LDMIB r12!, {r6, r7}) Load name in r6 & r7
+ldrh r12, [pc, 0x0C]! ; Skip BOX 5 Name
+0x00000000            ; Filler
+0xD9E1D5C8            ; ("Name")     Data
+0xFFFFFFFF            ; (Terminator) Data
+0xE9AB00C0            ; (STMIB r11!, {r6, r7}) Write trainer name
+

--- a/files_rs/misc/ChangeVar.txt
+++ b/files_rs/misc/ChangeVar.txt
@@ -1,6 +1,6 @@
 @@ title = "Change Variable"
 @@ author = "Adrichu00"
-@@ exit = "ReturnToOverworldFull_ENG"
+@@ exit = "ReturnToOverworldFull_{LANGNR}"
 
 ; Full list of vars: https://github.com/pret/pokeruby/blob/master/include/constants/vars.h
 ; This code won't work with special variables (0x80XX)

--- a/files_rs/misc/ChangeVar.txt
+++ b/files_rs/misc/ChangeVar.txt
@@ -1,0 +1,18 @@
+@@ title = "Change Variable"
+@@ author = "Adrichu00"
+@@ exit = "ReturnToOverworldFull_ENG"
+
+; Full list of vars: https://github.com/pret/pokeruby/blob/master/include/constants/vars.h
+; This code won't work with special variables (0x80XX)
+; It will work just with normal variables (0x40XX)
+var   = 0x00       ; You can use just the lower byte
+value = 0x0000     ; From 0x0000 to 0xFFFF
+
+; Do not modify this
+var_offset = 0x011978 - ((var & 0xFF) << 1)
+
+@@
+
+SUB r11, pc, {var_offset} ? ; r11 = &gSaveBlock1.vars[var]
+MOV r12, {value} ?          ; r12 = value
+STRH r12, [r11]             ; gSaveBlock1Ptr->vars[var] = value

--- a/files_rs/pkmn/ChangeLevel.txt
+++ b/files_rs/pkmn/ChangeLevel.txt
@@ -1,6 +1,6 @@
 @@ title = "Change Party Slot 2 Level"
 @@ Author = "Sleipnir, edited by PapaJefe (Ported by Adrichu00)"
-@@ exit = "ReturnToOverworldFull_{LANG}" ; You can set this to "Bootstrapped" if you have an exit code bootstrap
+@@ exit = "ReturnToOverworldFull_{LANGNR}" ; You can set this to "Bootstrapped" if you have an exit code bootstrap
 
 ; Please enter the level below in decimal.
 ; Use a Rare Candy to make the temporary level permanent.
@@ -10,9 +10,9 @@
 level = 98
 
 ; Do not change the parameters below:
-offset_{lang} = 0x0A20
+offset_{langnr} = 0x0A20
 offset_ger = 0x0A30
-offset = offset_{lang}
+offset = offset_{langnr}
 
 @@
 

--- a/files_rs/pkmn/ChangeLevel.txt
+++ b/files_rs/pkmn/ChangeLevel.txt
@@ -1,0 +1,26 @@
+@@ title = "Change Party Slot 2 Level"
+@@ Author = "Sleipnir, edited by PapaJefe (Ported by Adrichu00)"
+@@ exit = "ReturnToOverworldFull_{LANG}" ; You can set this to "Bootstrapped" if you have an exit code bootstrap
+
+; Please enter the level below in decimal.
+; Use a Rare Candy to make the temporary level permanent.
+; 98 allows for easy EV adjustments, and then a final Rare Candy to reach 100.
+; 49 allows Pokemon to re-enter Level 50 restricted battles.
+
+level = 98
+
+; Do not change the parameters below:
+offset_{lang} = 0x0A20
+offset_ger = 0x0A30
+offset = offset_{lang}
+
+@@
+
+; r12 = &gPlayerParty[1].level = 0x03004360 + 0x64 + 0x54 = 0x03004418
+; MOV r12, 0x03004418 ?
+MOV r12, 0x03000000
+ADC r12, r12, 0x39C0
+ADC r12, r12, {offset}
+ADC r12, r12, 0x38
+MOV r11, {level & 0xFF} ?  ; r11 = level
+STRB r11, [r12]            ; gPlayerParty[1].level = level

--- a/files_rs/pkmn/ReadPid.txt
+++ b/files_rs/pkmn/ReadPid.txt
@@ -1,6 +1,6 @@
 @@ title = "Read PID"
 @@ author = "E-Sh4rk (Ported by Adrichu00)"
-@@ exit = "ReturnToOverworldFull_{LANG}" ; You can set this to "Bootstrapped" if you have an exit code bootstrap
+@@ exit = "ReturnToOverworldFull_{LANGNR}" ; You can set this to "Bootstrapped" if you have an exit code bootstrap
 
 ; Store the PID of the second pokemon in the team in its attack and defense stats
 ; PID = attack + (defense*65536)

--- a/files_rs/pkmn/ReadPid.txt
+++ b/files_rs/pkmn/ReadPid.txt
@@ -1,0 +1,30 @@
+@@ title = "Read PID"
+@@ author = "E-Sh4rk (Ported by Adrichu00)"
+@@ exit = "ReturnToOverworldFull_{LANG}" ; You can set this to "Bootstrapped" if you have an exit code bootstrap
+
+; Store the PID of the second pokemon in the team in its attack and defense stats
+; PID = attack + (defense*65536)
+
+; NOTE: Deoxys stats are computed differently. For this reason, you can set this
+; parameter to 1 if you want to store its PID in the third pokemon in your
+; party. This can also be used for glitched mons whose summary is not stable.
+
+use_third_mon = 0 ; Set this to 1 in order to write the PID of the second mon in the stats of the third mon instead of its own stats.
+
+; Do not change the parameters below:
+offset_{lang} = 0x0A10
+offset_ger = 0x0A20
+offset = offset_{lang}
+
+@@
+
+; r12 = &gPokemonParty[1] = &gPlayerParty + 100 = 0x03004360 + 0x64 = 0x030043C4
+; MOV r12, 0x030043C4 ?
+MOV r12, 0x03000000
+ADC r12, r12, 0x3980
+ADC r12, r12, {offset}
+ADC r12, r12, 0x34
+LDRH r11, [r12, 0x00]                       ; Load lowPID of Pkmn 2
+STRH r11, [r12, {use_third_mon? 190: 90}]   ; Store lowPID in Attack stat
+LDRH r11, [r12, 0x02]                       ; Load highPID of Pkmn 2
+STRH r11, [r12, {use_third_mon? 192: 92}]   ; Store highPID in Defense stat


### PR DESCRIPTION
# Ported Codes
> [!NOTE]
> This codes have been ported to be used with *MoveACE* (aligned PC)
* *Read PID*
* *Change Level*
* *Change full trainer name (legal)*
* *Change Flag*
* *Change Variable*

## Length tests of *Change Flag* and *Change Variable* codes
As mentioned in #67,
> `MOV r12, {value} ?` takes at most 4 instructions for any 2 byte value

So, `flag_mask` (in *Change Flag*) and `value` (in *Change Variable*) loads take at most 4 instructions.

Tested in a way similar to #67 and #68:
* For *Change Flag* code: `SUB r11, pc, {flag_offset} ?` takes at most 3 instructions for any flag. Then, since the rest of the code takes 5 instructions, we can confirm that all cases (at most, `3 + 4 + 5 = 12` instructions) fit with *ReturnToOverworldShort* exits (space for 13 instructions).
* For *Change Variable* code: `SUB r11, pc, {var_offset} ?` takes at most 3 instructions for any variable. Then, since writing the variable takes one instruction more, we can confirm that all cases (at most, `3 + 4 + 1 = 8` instructions) fit with *ReturnToOverworldFull* exits (space for 9 instructions).
