### PR TITLE
Fateful Mew Text E4 Clarification

### DIFF
--- a/files_frlg/pkmn/FatefulMew.txt
+++ b/files_frlg/pkmn/FatefulMew.txt
@@ -6,7 +6,8 @@
 ; It can be found here:
 ; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
-; This code must be run at Indigo Plateau
+; This code must be run at Indigo Plateau, and 
+; the save must have cleared the Elite Four.
 ; After running, talk to far right Bookshelf.
 ; Refuse the Yes/No Box regarding Berry Powder
 ; Walk to the PokeMart NPC.

--- a/files_frlg/pkmn/FatefulMew_FR_ENG.txt
+++ b/files_frlg/pkmn/FatefulMew_FR_ENG.txt
@@ -6,7 +6,8 @@
 ; It can be found here:
 ; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
-; This code must be run at Indigo Plateau
+; This code must be run at Indigo Plateau, and 
+; the save must have cleared the Elite Four.
 ; After running, talk to the PokeMart NPC
 ; Refuse the Yes/No Box regarding Berry Powder
 ; Talk to the rightmost Bookshelf by the PC, and
@@ -29,4 +30,5 @@ sbc r12, r12, {offset} ? ; SBC from Berry Powder Script to Deoxys
 str r12, [r11, 0xA8]!  ; Write Deoxys Battle to NPC 7 (Right Bookshelf)
 sbc r11, r4, 0x27AE ?    ; Use R4 offset to put Var 0x8009 in R11                    
 mov r12, {0x0097} ?    ; Store Mew Species in R12
+
 strh r12, [r11, 0xCA]    ; Write Mew Species to Var 0x8009

--- a/files_frlg/pkmn/FatefulMew_FR_FRA.txt
+++ b/files_frlg/pkmn/FatefulMew_FR_FRA.txt
@@ -6,7 +6,8 @@
 ; It can be found here:
 ; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
-; This code must be run at Indigo Plateau
+; This code must be run at Indigo Plateau, and 
+; the save must have cleared the Elite Four.
 ; After running, talk to the PokeMart NPC
 ; Refuse the Yes/No Box regarding Berry Powder
 ; Talk to the rightmost Bookshelf by the PC, and
@@ -29,4 +30,5 @@ sbc r12, r12, {offset} ? ; SBC from Berry Powder Script to Deoxys
 str r12, [r11, 0xA8]!  ; Write Deoxys Battle to NPC 7 (Right Bookshelf)
 sbc r11, r4, 0x27AE ?    ; Use R4 offset to put Var 0x8009 in R11                    
 mov r12, {0x0097} ?    ; Store Mew Species in R12
+
 strh r12, [r11, 0xCA]    ; Write Mew Species to Var 0x8009

--- a/files_frlg/pkmn/FatefulMew_FR_GER.txt
+++ b/files_frlg/pkmn/FatefulMew_FR_GER.txt
@@ -6,7 +6,8 @@
 ; It can be found here:
 ; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
-; This code must be run at Indigo Plateau
+; This code must be run at Indigo Plateau, and 
+; the save must have cleared the Elite Four.
 ; After running, talk to the PokeMart NPC
 ; Refuse the Yes/No Box regarding Berry Powder
 ; Talk to the rightmost Bookshelf by the PC, and
@@ -29,4 +30,5 @@ sbc r12, r12, {offset} ? ; SBC from Berry Powder Script to Deoxys
 str r12, [r11, 0xA8]!  ; Write Deoxys Battle to NPC 7 (Right Bookshelf)
 sbc r11, r4, 0x27AE ?    ; Use R4 offset to put Var 0x8009 in R11                    
 mov r12, {0x0097} ?    ; Store Mew Species in R12
+
 strh r12, [r11, 0xCA]    ; Write Mew Species to Var 0x8009

--- a/files_frlg/pkmn/FatefulMew_FR_ITA.txt
+++ b/files_frlg/pkmn/FatefulMew_FR_ITA.txt
@@ -6,7 +6,8 @@
 ; It can be found here:
 ; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
-; This code must be run at Indigo Plateau
+; This code must be run at Indigo Plateau, and 
+; the save must have cleared the Elite Four.
 ; After running, talk to the PokeMart NPC
 ; Refuse the Yes/No Box regarding Berry Powder
 ; Talk to the rightmost Bookshelf by the PC, and
@@ -29,4 +30,5 @@ sbc r12, r12, {offset} ? ; SBC from Berry Powder Script to Deoxys
 str r12, [r11, 0xA8]!  ; Write Deoxys Battle to NPC 7 (Right Bookshelf)
 sbc r11, r4, 0x27AE ?    ; Use R4 offset to put Var 0x8009 in R11                    
 mov r12, {0x0097} ?    ; Store Mew Species in R12
+
 strh r12, [r11, 0xCA]    ; Write Mew Species to Var 0x8009

--- a/files_frlg/pkmn/FatefulMew_FR_Rev1_ENG.txt
+++ b/files_frlg/pkmn/FatefulMew_FR_Rev1_ENG.txt
@@ -6,7 +6,8 @@
 ; It can be found here:
 ; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
-; This code must be run at Indigo Plateau
+; This code must be run at Indigo Plateau, and 
+; the save must have cleared the Elite Four.
 ; After running, talk to the PokeMart NPC
 ; Refuse the Yes/No Box regarding Berry Powder
 ; Talk to the rightmost Bookshelf by the PC, and
@@ -29,4 +30,5 @@ sbc r12, r12, {offset} ? ; SBC from Berry Powder Script to Deoxys
 str r12, [r11, 0xA8]!  ; Write Deoxys Battle to NPC 7 (Right Bookshelf)
 sbc r11, r4, 0x27AE ?    ; Use R4 offset to put Var 0x8009 in R11                    
 mov r12, {0x0097} ?    ; Store Mew Species in R12
+
 strh r12, [r11, 0xCA]    ; Write Mew Species to Var 0x8009

--- a/files_frlg/pkmn/FatefulMew_FR_SPA.txt
+++ b/files_frlg/pkmn/FatefulMew_FR_SPA.txt
@@ -6,7 +6,8 @@
 ; It can be found here:
 ; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
-; This code must be run at Indigo Plateau
+; This code must be run at Indigo Plateau, and 
+; the save must have cleared the Elite Four.
 ; After running, talk to the PokeMart NPC
 ; Refuse the Yes/No Box regarding Berry Powder
 ; Talk to the rightmost Bookshelf by the PC, and
@@ -29,4 +30,5 @@ sbc r12, r12, {offset} ? ; SBC from Berry Powder Script to Deoxys
 str r12, [r11, 0xA8]!  ; Write Deoxys Battle to NPC 7 (Right Bookshelf)
 sbc r11, r4, 0x27AE ?    ; Use R4 offset to put Var 0x8009 in R11                    
 mov r12, {0x0097} ?    ; Store Mew Species in R12
+
 strh r12, [r11, 0xCA]    ; Write Mew Species to Var 0x8009

--- a/files_frlg/pkmn/FatefulMew_LG_ENG.txt
+++ b/files_frlg/pkmn/FatefulMew_LG_ENG.txt
@@ -6,7 +6,8 @@
 ; It can be found here:
 ; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
-; This code must be run at Indigo Plateau
+; This code must be run at Indigo Plateau, and 
+; the save must have cleared the Elite Four.
 ; After running, talk to the PokeMart NPC
 ; Refuse the Yes/No Box regarding Berry Powder
 ; Talk to the rightmost Bookshelf by the PC, and
@@ -29,4 +30,5 @@ sbc r12, r12, {offset} ? ; SBC from Berry Powder Script to Deoxys
 str r12, [r11, 0xA8]!  ; Write Deoxys Battle to NPC 7 (Right Bookshelf)
 sbc r11, r4, 0x27AE ?    ; Use R4 offset to put Var 0x8009 in R11                    
 mov r12, {0x0097} ?    ; Store Mew Species in R12
+
 strh r12, [r11, 0xCA]    ; Write Mew Species to Var 0x8009

--- a/files_frlg/pkmn/FatefulMew_LG_FRA.txt
+++ b/files_frlg/pkmn/FatefulMew_LG_FRA.txt
@@ -6,7 +6,8 @@
 ; It can be found here:
 ; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
-; This code must be run at Indigo Plateau
+; This code must be run at Indigo Plateau, and 
+; the save must have cleared the Elite Four.
 ; After running, talk to the PokeMart NPC
 ; Refuse the Yes/No Box regarding Berry Powder
 ; Talk to the rightmost Bookshelf by the PC, and
@@ -29,4 +30,5 @@ sbc r12, r12, {offset} ? ; SBC from Berry Powder Script to Deoxys
 str r12, [r11, 0xA8]!  ; Write Deoxys Battle to NPC 7 (Right Bookshelf)
 sbc r11, r4, 0x27AE ?    ; Use R4 offset to put Var 0x8009 in R11                    
 mov r12, {0x0097} ?    ; Store Mew Species in R12
+
 strh r12, [r11, 0xCA]    ; Write Mew Species to Var 0x8009

--- a/files_frlg/pkmn/FatefulMew_LG_GER.txt
+++ b/files_frlg/pkmn/FatefulMew_LG_GER.txt
@@ -6,7 +6,8 @@
 ; It can be found here:
 ; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
-; This code must be run at Indigo Plateau
+; This code must be run at Indigo Plateau, and 
+; the save must have cleared the Elite Four.
 ; After running, talk to the PokeMart NPC
 ; Refuse the Yes/No Box regarding Berry Powder
 ; Talk to the rightmost Bookshelf by the PC, and
@@ -29,4 +30,5 @@ sbc r12, r12, {offset} ? ; SBC from Berry Powder Script to Deoxys
 str r12, [r11, 0xA8]!  ; Write Deoxys Battle to NPC 7 (Right Bookshelf)
 sbc r11, r4, 0x27AE ?    ; Use R4 offset to put Var 0x8009 in R11                    
 mov r12, {0x0097} ?    ; Store Mew Species in R12
+
 strh r12, [r11, 0xCA]    ; Write Mew Species to Var 0x8009

--- a/files_frlg/pkmn/FatefulMew_LG_ITA.txt
+++ b/files_frlg/pkmn/FatefulMew_LG_ITA.txt
@@ -6,7 +6,8 @@
 ; It can be found here:
 ; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
-; This code must be run at Indigo Plateau
+; This code must be run at Indigo Plateau, and 
+; the save must have cleared the Elite Four.
 ; After running, talk to the PokeMart NPC
 ; Refuse the Yes/No Box regarding Berry Powder
 ; Talk to the rightmost Bookshelf by the PC, and
@@ -29,4 +30,5 @@ sbc r12, r12, {offset} ? ; SBC from Berry Powder Script to Deoxys
 str r12, [r11, 0xA8]!  ; Write Deoxys Battle to NPC 7 (Right Bookshelf)
 sbc r11, r4, 0x27AE ?    ; Use R4 offset to put Var 0x8009 in R11                    
 mov r12, {0x0097} ?    ; Store Mew Species in R12
+
 strh r12, [r11, 0xCA]    ; Write Mew Species to Var 0x8009

--- a/files_frlg/pkmn/FatefulMew_LG_Rev1_ENG.txt
+++ b/files_frlg/pkmn/FatefulMew_LG_Rev1_ENG.txt
@@ -6,7 +6,8 @@
 ; It can be found here:
 ; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
-; This code must be run at Indigo Plateau
+; This code must be run at Indigo Plateau, and 
+; the save must have cleared the Elite Four.
 ; After running, talk to the PokeMart NPC
 ; Refuse the Yes/No Box regarding Berry Powder
 ; Talk to the rightmost Bookshelf by the PC, and
@@ -29,4 +30,5 @@ sbc r12, r12, {offset} ? ; SBC from Berry Powder Script to Deoxys
 str r12, [r11, 0xA8]!  ; Write Deoxys Battle to NPC 7 (Right Bookshelf)
 sbc r11, r4, 0x27AE ?    ; Use R4 offset to put Var 0x8009 in R11                    
 mov r12, {0x0097} ?    ; Store Mew Species in R12
+
 strh r12, [r11, 0xCA]    ; Write Mew Species to Var 0x8009

--- a/files_frlg/pkmn/FatefulMew_LG_SPA.txt
+++ b/files_frlg/pkmn/FatefulMew_LG_SPA.txt
@@ -6,7 +6,8 @@
 ; It can be found here:
 ; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
-; This code must be run at Indigo Plateau
+; This code must be run at Indigo Plateau, and 
+; the save must have cleared the Elite Four.
 ; After running, talk to the PokeMart NPC
 ; Refuse the Yes/No Box regarding Berry Powder
 ; Talk to the rightmost Bookshelf by the PC, and
@@ -29,4 +30,5 @@ sbc r12, r12, {offset} ? ; SBC from Berry Powder Script to Deoxys
 str r12, [r11, 0xA8]!  ; Write Deoxys Battle to NPC 7 (Right Bookshelf)
 sbc r11, r4, 0x27AE ?    ; Use R4 offset to put Var 0x8009 in R11                    
 mov r12, {0x0097} ?    ; Store Mew Species in R12
+
 strh r12, [r11, 0xCA]    ; Write Mew Species to Var 0x8009


### PR DESCRIPTION
Added some text to clarify the need to have cleared the Elite Four in order for this code to work.

It turns out some of the NPCs don't appear in the Indigo Plateau PokeCenter until after the E4 has been beaten at least once, causing this to fail.