### PR TITLE
Remove Japanese language properties from certain FR/LG codes

### DIFF
--- a/files_frlg/list.json
+++ b/files_frlg/list.json
@@ -187,8 +187,6 @@
     "ger": "pkmn/PokemonFromNothing.txt",
     "spa": "pkmn/PokemonFromNothing.txt",
     "ita": "pkmn/PokemonFromNothing.txt",
-    "jap0": "pkmn/PokemonFromNothing.txt",
-    "jap1": "pkmn/PokemonFromNothing.txt",
     "game": ["fr", "lg"],
     "cat": ["pkmn"]
   },
@@ -211,8 +209,6 @@
     "ger": "pkmn/Create6IVEgg.txt",
     "spa": "pkmn/Create6IVEgg.txt",
     "ita": "pkmn/Create6IVEgg.txt",
-    "jap0": "pkmn/Create6IVEgg.txt",
-    "jap1": "pkmn/Create6IVEgg.txt",
     "game": ["fr", "lg"],
     "cat": ["misc"]
   },
@@ -224,8 +220,6 @@
     "ger": "pkmn/HiddenPowerEgg.txt",
     "spa": "pkmn/HiddenPowerEgg.txt",
     "ita": "pkmn/HiddenPowerEgg.txt",
-    "jap0": "pkmn/HiddenPowerEgg.txt",
-    "jap1": "pkmn/HiddenPowerEgg.txt",
     "game": ["fr", "lg"],
     "cat": ["misc"]
   },


### PR DESCRIPTION
These codes will not work under the standard grab ACE set up in Japanese FireRed/LeafGreen (written in ARM, whereas ACE species is Thumb without a bootstrap). For the latter two, the further instructions in the code won't work under Japanese FR/LG mail glitch.

- "Create Pokemon species from nothing"
- "Create 6IV Egg from Nothing"
- "Create Egg with Custom Hidden Power (bootstrapped)"