### PR TITLE
PRNG code changes, and a small optimization for Gift Pokemon

### DIFF
--- a/files_frlg/pkmn/CreateAnyGiftPokemonBootstrapped.txt
+++ b/files_frlg/pkmn/CreateAnyGiftPokemonBootstrapped.txt
@@ -2,6 +2,9 @@
 @@ author = "Theocatic"				
 @@ exit = "Bootstrapped"
 
+; This code requires a Box 14 exit code for grab ACE.
+; It can be found here:
+; https://github.com/it-is-final/PokeG3ACE/blob/main/ace_notes/ExitCodes/FRLG_GrabACE_ShortExit.md
 
 ;After Executing this code talk to the Old Gentleman NPC in the Viridian City Pokemon Center similar to the Run script via NPC code.
 
@@ -24,7 +27,6 @@ str r11, [r10, {NPCOffset}]!
 mov r12, {ScriptStart} ?
 str r12, [r11]!
 mov r12, {ScriptEnd} ?
-0xE7ABCCAE ; STR r12, [r11, lr, LSR #25]!
 0xE7ABCCAE ; STR r12, [r11, lr, LSR #25]!
 0xE7ABCCAE ; STR r12, [r11, lr, LSR #25]!
 Adc r12, 0x02 ?

--- a/files_frlg/rng/SeedChangeAndWarpBootstrappedEN.txt
+++ b/files_frlg/rng/SeedChangeAndWarpBootstrappedEN.txt
@@ -9,24 +9,29 @@
 ;this code will set PRNG to the desired seed when executed. Talk to the NPC you set in the map to warp afterwards. Best ran in the daycare
 
 
-;Map Bank andMap ID values can be found here https://pastebin.com/peDhNbEt
+;Map Bank and Map ID values can be found here https://pastebin.com/peDhNbEt
 
 
-MapID = 0x3802
+
+inaccurate_emu = 0
 
 DesiredSeed = 0x1234ABCD
 
-NPC = 1 ;sets which NPC on the map to run though. NPC 1, 2 and 3 are usable. 
+npc_id = 1 ;Sets which NPC on the map to run the script through.
 
-;Do not modify these values
-ScriptStart =(MapID * 0x100) + 0x39
-NPCOffset = 0x1A5 + (NPC * 0x18)
+map_id = 0x3802
+
+warp = 0 ;Change this to change which entrance you teleport to. Use Warp 3 for Zapdos
+
+script0 = (warp << 24) | ((map_id & 0xffff) << 8) | 0x39
+npc_offset = 0x1A5 + (npc_id * 0x18) + ((!!inaccurate_emu) << 1) + 0x400  ; 0x400 added to avoid quote characters
+
 @@                
 
-sbc r10, pc, 0xBA00
+sbc r10, pc, 0xBE00
 adc r11, r4, 0x300
-str r11, [r10, {NPCOffset}]!
-mov r12, {ScriptStart} ?
+str r11, [r10, {npc_offset}]!
+mov r12, {script0} ?
 str r12, [r11]!
 mov r12, {DesiredSeed} ?
 BIC r11, r13, #0x2F00 ;sets r11 to 0x03005000 gRNGValue

--- a/files_frlg/rng/SeedChangeAndWarpBootstrappedEU.txt
+++ b/files_frlg/rng/SeedChangeAndWarpBootstrappedEU.txt
@@ -9,24 +9,29 @@
 ;this code will set PRNG to the desired seed when executed. Talk to the NPC you set in the map to warp afterwards. Best ran in the daycare
 
 
-;Map Bank andMap ID values can be found here https://pastebin.com/peDhNbEt
+;Map Bank and Map ID values can be found here https://pastebin.com/peDhNbEt
 
 
-MapID = 0x3802
+
+inaccurate_emu = 0
 
 DesiredSeed = 0x1234ABCD
 
-NPC = 1 ;sets which NPC on the map to run though. NPC 1, 2 and 3 are usable. 
+npc_id = 1 ;Sets which NPC on the map to run the script through.
 
-;Do not modify these values
-ScriptStart =(MapID * 0x100) + 0x39
-NPCOffset = 0x1A5 + (NPC * 0x18)
+map_id = 0x3802
+
+warp = 0 ;Change this to change which entrance you teleport to. Use Warp 3 for Zapdos
+
+script0 = (warp << 24) | ((map_id & 0xffff) << 8) | 0x39
+npc_offset = 0x1A5 + (npc_id * 0x18) + ((!!inaccurate_emu) << 1) + 0x400  ; 0x400 added to avoid quote characters
+
 @@                
 
-sbc r10, pc, 0xBA00
+sbc r10, pc, 0xBE00
 adc r11, r4, 0x300
-str r11, [r10, {NPCOffset}]!
-mov r12, {ScriptStart} ?
+str r11, [r10, {npc_offset}]!
+mov r12, {script0} ?
 str r12, [r11]!
 mov r12, {DesiredSeed} ?
 BIC r11, r13, #0x2F00 ;sets r11 to 0x03005000 gRNGValue


### PR DESCRIPTION
Added the ability to dictate which entrance the PRNG + Teleport Bootstrapped code sends you to. This allows for RNG manipulation of Zapdos now. 

Also removed an extra unneeded line in the Create Gift Pokemon code, and added a reference to the box 14 + wallpaper exit that was missing.