### PR TITLE
New exit codes for FR/LG and R/S

### DIFF
--- a/files_frlg/exit.txt
+++ b/files_frlg/exit.txt
@@ -701,6 +701,7 @@ adc r0,r12, 0xC6                ;  R0=R12+C6=8015AC9=ReturnFromBattleToOverworld
 
 @@ filename = "GrabACEExit"
 @@ start = 84
+@@ fill = true
 @@
 
 movs r0, #0x0

--- a/files_frlg/exit.txt
+++ b/files_frlg/exit.txt
@@ -709,7 +709,7 @@ ADCS r15, r12, #0x370
 
 ====================
 
-@@ filename = "ROM_BX_r0_Box5"
+@@ filename = "ROM_BX_r0_Box6"
 @@ start = 48
 @@ fill = false
 @@
@@ -739,7 +739,7 @@ ADCS r15, r12, #0x398
 
 ====================
 
-@@ filename = "ROM_BX_lr_Box5"
+@@ filename = "ROM_BX_lr_Box6"
 @@ start = 48
 @@ fill = false
 @@
@@ -770,7 +770,7 @@ ADCS r15, r12, #0x398
 
 ====================
 
-@@ filename = "ROM_BX_lr_Box5_Grab"
+@@ filename = "ROM_BX_lr_Box6_Grab"
 @@ start = 44
 @@ fill = false
 @@
@@ -801,7 +801,7 @@ movs r15, #0x324
 
 ====================
 
-@@ filename = "BIOS_BX_r0_Box5"
+@@ filename = "BIOS_BX_r0_Box6"
 @@ start = 52
 @@ fill = false
 @@
@@ -828,7 +828,7 @@ movs r15, #0x354
 
 ====================
 
-@@ filename = "BIOS_BX_lr_Box5"
+@@ filename = "BIOS_BX_lr_Box6"
 @@ start = 52
 @@ fill = false
 @@
@@ -856,7 +856,7 @@ movs r15, #0x354
 
 ====================
 
-@@ filename = "BIOS_BX_lr_Box5_Grab"
+@@ filename = "BIOS_BX_lr_Box6_Grab"
 @@ start = 48
 @@ fill = false
 @@

--- a/files_frlg/exit.txt
+++ b/files_frlg/exit.txt
@@ -699,12 +699,179 @@ adc r0,r12, 0xC6                ;  R0=R12+C6=8015AC9=ReturnFromBattleToOverworld
 
 ====================
 
+@@ filename = "ROM_BX_r0_Box2"
+@@ start = 12
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_r0_Box5"
+@@ start = 48
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_r0_Box10"
+@@ start = 84
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box2"
+@@ start = 12
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x398
+
+====================
+
+@@ filename = "ROM_BX_lr_Box5"
+@@ start = 48
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x398
+
+====================
+
+@@ filename = "ROM_BX_lr_Box10"
+@@ start = 84
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x398
+
+====================
+
+@@ filename = "ROM_BX_lr_Box2_Grab"
+@@ start = 8
+@@ fill = false
+@@
+
+BIC r0, r0, #0xff
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x398
+
+====================
+
+@@ filename = "ROM_BX_lr_Box5_Grab"
+@@ start = 44
+@@ fill = false
+@@
+
+BIC r0, r0, #0xff
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x398
+
+====================
+
+@@ filename = "ROM_BX_lr_Box10_Grab"
+@@ start = 80
+@@ fill = false
+@@
+
+BIC r0, r0, #0xff
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x398
+
+====================
+
+@@ filename = "BIOS_BX_r0_Box2"
+@@ start = 16
+@@ fill = false
+@@
+
+movs r15, #0x324
+
+====================
+
+@@ filename = "BIOS_BX_r0_Box5"
+@@ start = 52
+@@ fill = false
+@@
+
+movs r15, #0x324
+
+====================
+
+@@ filename = "BIOS_BX_r0_Box10"
+@@ start = 88
+@@ fill = false
+@@
+
+movs r15, #0x324
+
+====================
+
+@@ filename = "BIOS_BX_lr_Box2"
+@@ start = 16
+@@ fill = false
+@@
+
+movs r15, #0x354
+
+====================
+
+@@ filename = "BIOS_BX_lr_Box5"
+@@ start = 52
+@@ fill = false
+@@
+
+movs r15, #0x354
+
+====================
+
+@@ filename = "BIOS_BX_lr_Box10"
+@@ start = 88
+@@ fill = false
+@@
+
+movs r15, #0x354
+
+====================
+
+@@ filename = "BIOS_BX_lr_Box2_Grab"
+@@ start = 12
+@@ fill = false
+@@
+
+mov r0, #0
+movs r15, #0x354
+
+====================
+
+@@ filename = "BIOS_BX_lr_Box5_Grab"
+@@ start = 48
+@@ fill = false
+@@
+
+mov r0, #0
+movs r15, #0x354
+
+====================
+
 @@ filename = "GrabACEExit"
 @@ start = 84
 @@ fill = true
 @@
 
-movs r0, #0x0
+mov r0, #0x0
 movs pc, #0x354
 
 ====================

--- a/files_frlg/exit.txt
+++ b/files_frlg/exit.txt
@@ -868,7 +868,7 @@ movs r15, #0x354
 
 @@ filename = "GrabACEExit"
 @@ start = 84
-@@ fill = true
+@@ fill = false
 @@
 
 mov r0, #0x0

--- a/files_rs/exit.txt
+++ b/files_rs/exit.txt
@@ -451,7 +451,7 @@ ADCS r15, r12, #0x314
 
 ====================
 
-@@ filename = "ROM_BX_r0_Box5_ENG"
+@@ filename = "ROM_BX_r0_Box6_ENG"
 @@ start = 44
 @@ fill = false
 @@
@@ -485,7 +485,7 @@ ADCS r15, r12, #0x33c
 
 ====================
 
-@@ filename = "ROM_BX_lr_Box5_ENG"
+@@ filename = "ROM_BX_lr_Box6_ENG"
 @@ start = 44
 @@ fill = false
 @@
@@ -517,7 +517,7 @@ ADCS r15, r12, #0x348
 
 ====================
 
-@@ filename = "ROM_BX_r0_Box5_EUR"
+@@ filename = "ROM_BX_r0_Box6_EUR"
 @@ start = 48
 @@ fill = false
 @@
@@ -547,7 +547,7 @@ ADCS r15, r12, #0x370
 
 ====================
 
-@@ filename = "ROM_BX_lr_Box5_EUR"
+@@ filename = "ROM_BX_lr_Box6_EUR"
 @@ start = 48
 @@ fill = false
 @@
@@ -578,7 +578,7 @@ ADCS r15, r12, #0x370
 
 ====================
 
-@@ filename = "ROM_BX_lr_Box5_EUR_Grab"
+@@ filename = "ROM_BX_lr_Box6_EUR_Grab"
 @@ start = 44
 @@ fill = false
 @@
@@ -609,7 +609,7 @@ movs r15, #0x324
 
 ====================
 
-@@ filename = "BIOS_BX_r0_Box5"
+@@ filename = "BIOS_BX_r0_Box6"
 @@ start = 52
 @@ fill = false
 @@
@@ -636,7 +636,7 @@ movs r15, #0x354
 
 ====================
 
-@@ filename = "BIOS_BX_lr_Box5"
+@@ filename = "BIOS_BX_lr_Box6"
 @@ start = 52
 @@ fill = false
 @@
@@ -664,7 +664,7 @@ movs r15, #0x354
 
 ====================
 
-@@ filename = "BIOS_BX_lr_Box5_Grab"
+@@ filename = "BIOS_BX_lr_Box6_Grab"
 @@ start = 48
 @@ fill = false
 @@

--- a/files_rs/exit.txt
+++ b/files_rs/exit.txt
@@ -507,6 +507,55 @@ ADCS r15, r12, #0x33c
 
 ====================
 
+@@ filename = "ROM_BX_lr_Box2_ENG_Grab"
+@@ start = 8
+@@ fill = false
+@@
+
+// This is identical to `ROM_BX_lr_Box2_ENG`, this is created for
+// consistency with European versions of the exit code where they do
+// have a shorter method of doing BX lr by itself. Allows for easier
+// `LANG` substitution.
+
+0xe3e300ff ; MVN r0, #0xff
+BIC r12, r0, #0xf8000002
+ADCS r15, r12, #0x33c
+
+
+====================
+
+@@ filename = "ROM_BX_lr_Box6_ENG_Grab"
+@@ start = 44
+@@ fill = false
+@@
+
+// This is identical to `ROM_BX_lr_Box6_ENG`, this is created for
+// consistency with European versions of the exit code where they do
+// have a shorter method of doing BX lr by itself. Allows for easier
+// `LANG` substitution.
+
+0xe3e300ff ; MVN r0, #0xff
+BIC r12, r0, #0xf8000002
+ADCS r15, r12, #0x33c
+
+====================
+
+@@ filename = "ROM_BX_lr_Box10_ENG_Grab"
+@@ start = 80
+@@ fill = false
+@@
+
+// This is identical to `ROM_BX_lr_Box10_ENG`, this is created for
+// consistency with European versions of the exit code where they do
+// have a shorter method of doing BX lr by itself. Allows for easier
+// `LANG` substitution.
+
+0xe3e300ff ; MVN r0, #0xff
+BIC r12, r0, #0xf8000002
+ADCS r15, r12, #0x33c
+
+====================
+
 @@ filename = "ROM_BX_r0_Box2_EUR"
 @@ start = 12
 @@ fill = false
@@ -542,6 +591,11 @@ ADCS r15, r12, #0x348
 @@ fill = false
 @@
 
+// French, Italian, German, and Spanish version of this exit code are
+// identical to this exit code. The individual language versions only
+// exist for ease of using `LANG` to substitute in the individual
+// language.
+
 0xe3bdc3c2 ; MOVS r12, #0x8000003
 ADCS r15, r12, #0x370
 
@@ -551,6 +605,11 @@ ADCS r15, r12, #0x370
 @@ start = 48
 @@ fill = false
 @@
+
+// French, Italian, German, and Spanish version of this exit code are
+// identical to this exit code. The individual language versions only
+// exist for ease of using `LANG` to substitute in the individual
+// language.
 
 0xe3bdc3c2 ; MOVS r12, #0x8000003
 ADCS r15, r12, #0x370
@@ -562,6 +621,11 @@ ADCS r15, r12, #0x370
 @@ fill = false
 @@
 
+// French, Italian, German, and Spanish version of this exit code are
+// identical to this exit code. The individual language versions only
+// exist for ease of using `LANG` to substitute in the individual
+// language.
+
 0xe3bdc3c2 ; MOVS r12, #0x8000003
 ADCS r15, r12, #0x370
 
@@ -571,6 +635,11 @@ ADCS r15, r12, #0x370
 @@ start = 8
 @@ fill = false
 @@
+
+// French, Italian, German, and Spanish version of this exit code are
+// identical to this exit code. The individual language versions only
+// exist for ease of using `LANG` to substitute in the individual
+// language.
 
 BIC r0, r0, #0xff
 0xe3bdc3c2 ; MOVS r12, #0x8000003
@@ -583,6 +652,11 @@ ADCS r15, r12, #0x370
 @@ fill = false
 @@
 
+// French, Italian, German, and Spanish version of this exit code are
+// identical to this exit code. The individual language versions only
+// exist for ease of using `LANG` to substitute in the individual
+// language.
+
 BIC r0, r0, #0xff
 0xe3bdc3c2 ; MOVS r12, #0x8000003
 ADCS r15, r12, #0x370
@@ -590,6 +664,384 @@ ADCS r15, r12, #0x370
 ====================
 
 @@ filename = "ROM_BX_lr_Box10_EUR_Grab"
+@@ start = 80
+@@ fill = false
+@@
+
+// French, Italian, German, and Spanish version of this exit code are
+// identical to this exit code. The individual language versions only
+// exist for ease of using `LANG` to substitute in the individual
+// language.
+
+BIC r0, r0, #0xff
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+
+====================
+
+@@ filename = "ROM_BX_r0_Box2_FRA"
+@@ start = 12
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x348
+
+====================
+
+@@ filename = "ROM_BX_r0_Box6_FRA"
+@@ start = 48
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x348
+
+====================
+
+@@ filename = "ROM_BX_r0_Box10_FRA"
+@@ start = 84
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x348
+
+====================
+
+@@ filename = "ROM_BX_lr_Box2_FRA"
+@@ start = 12
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box6_FRA"
+@@ start = 48
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box10_FRA"
+@@ start = 84
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box2_FRA_Grab"
+@@ start = 8
+@@ fill = false
+@@
+
+BIC r0, r0, #0xff
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box6_FRA_Grab"
+@@ start = 44
+@@ fill = false
+@@
+
+BIC r0, r0, #0xff
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box10_FRA_Grab"
+@@ start = 80
+@@ fill = false
+@@
+
+BIC r0, r0, #0xff
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_r0_Box2_ITA"
+@@ start = 12
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x348
+
+====================
+
+@@ filename = "ROM_BX_r0_Box6_ITA"
+@@ start = 48
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x348
+
+====================
+
+@@ filename = "ROM_BX_r0_Box10_ITA"
+@@ start = 84
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x348
+
+====================
+
+@@ filename = "ROM_BX_lr_Box2_ITA"
+@@ start = 12
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box6_ITA"
+@@ start = 48
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box10_ITA"
+@@ start = 84
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box2_ITA_Grab"
+@@ start = 8
+@@ fill = false
+@@
+
+BIC r0, r0, #0xff
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box6_ITA_Grab"
+@@ start = 44
+@@ fill = false
+@@
+
+BIC r0, r0, #0xff
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box10_ITA_Grab"
+@@ start = 80
+@@ fill = false
+@@
+
+BIC r0, r0, #0xff
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_r0_Box2_GER"
+@@ start = 12
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x348
+
+====================
+
+@@ filename = "ROM_BX_r0_Box6_GER"
+@@ start = 48
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x348
+
+====================
+
+@@ filename = "ROM_BX_r0_Box10_GER"
+@@ start = 84
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x348
+
+====================
+
+@@ filename = "ROM_BX_lr_Box2_GER"
+@@ start = 12
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box6_GER"
+@@ start = 48
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box10_GER"
+@@ start = 84
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box2_GER_Grab"
+@@ start = 8
+@@ fill = false
+@@
+
+BIC r0, r0, #0xff
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box6_GER_Grab"
+@@ start = 44
+@@ fill = false
+@@
+
+BIC r0, r0, #0xff
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box10_GER_Grab"
+@@ start = 80
+@@ fill = false
+@@
+
+BIC r0, r0, #0xff
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_r0_Box2_SPA"
+@@ start = 12
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x348
+
+====================
+
+@@ filename = "ROM_BX_r0_Box6_SPA"
+@@ start = 48
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x348
+
+====================
+
+@@ filename = "ROM_BX_r0_Box10_SPA"
+@@ start = 84
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x348
+
+====================
+
+@@ filename = "ROM_BX_lr_Box2_SPA"
+@@ start = 12
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box6_SPA"
+@@ start = 48
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box10_SPA"
+@@ start = 84
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box2_SPA_Grab"
+@@ start = 8
+@@ fill = false
+@@
+
+BIC r0, r0, #0xff
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box6_SPA_Grab"
+@@ start = 44
+@@ fill = false
+@@
+
+BIC r0, r0, #0xff
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box10_SPA_Grab"
 @@ start = 80
 @@ fill = false
 @@

--- a/files_rs/exit.txt
+++ b/files_rs/exit.txt
@@ -440,6 +440,250 @@ ldr r0, [r15, -0x4]             ;  Load CB2_LoadMap2SJAP
 
 ====================
 
+@@ filename = "ROM_BX_r0_Box2_ENG"
+@@ start = 8
+@@ fill = false
+@@
+
+0xe3e3c0ff ; MVN r12, #0xff
+BIC r12, r12, #0xf8000002
+ADCS r15, r12, #0x314
+
+====================
+
+@@ filename = "ROM_BX_r0_Box5_ENG"
+@@ start = 44
+@@ fill = false
+@@
+
+0xe3e3c0ff ; MVN r12, #0xff
+BIC r12, r12, #0xf8000002
+ADCS r15, r12, #0x314
+
+====================
+
+@@ filename = "ROM_BX_r0_Box10_ENG"
+@@ start = 80
+@@ fill = false
+@@
+
+0xe3e3c0ff ; MVN r12, #0xff
+BIC r12, r12, #0xf8000002
+ADCS r15, r12, #0x314
+
+====================
+
+@@ filename = "ROM_BX_lr_Box2_ENG"
+@@ start = 8
+@@ fill = false
+@@
+
+0xe3e300ff ; MVN r0, #0xff
+BIC r12, r0, #0xf8000002
+ADCS r15, r12, #0x33c
+
+
+====================
+
+@@ filename = "ROM_BX_lr_Box5_ENG"
+@@ start = 44
+@@ fill = false
+@@
+
+0xe3e300ff ; MVN r0, #0xff
+BIC r12, r0, #0xf8000002
+ADCS r15, r12, #0x33c
+
+====================
+
+@@ filename = "ROM_BX_lr_Box10_ENG"
+@@ start = 80
+@@ fill = false
+@@
+
+0xe3e300ff ; MVN r0, #0xff
+BIC r12, r0, #0xf8000002
+ADCS r15, r12, #0x33c
+
+====================
+
+@@ filename = "ROM_BX_r0_Box2_EUR"
+@@ start = 12
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x348
+
+====================
+
+@@ filename = "ROM_BX_r0_Box5_EUR"
+@@ start = 48
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x348
+
+====================
+
+@@ filename = "ROM_BX_r0_Box10_EUR"
+@@ start = 84
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x348
+
+====================
+
+@@ filename = "ROM_BX_lr_Box2_EUR"
+@@ start = 12
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box5_EUR"
+@@ start = 48
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box10_EUR"
+@@ start = 84
+@@ fill = false
+@@
+
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box2_EUR_Grab"
+@@ start = 8
+@@ fill = false
+@@
+
+BIC r0, r0, #0xff
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box5_EUR_Grab"
+@@ start = 44
+@@ fill = false
+@@
+
+BIC r0, r0, #0xff
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "ROM_BX_lr_Box10_EUR_Grab"
+@@ start = 80
+@@ fill = false
+@@
+
+BIC r0, r0, #0xff
+0xe3bdc3c2 ; MOVS r12, #0x8000003
+ADCS r15, r12, #0x370
+
+====================
+
+@@ filename = "BIOS_BX_r0_Box2"
+@@ start = 16
+@@ fill = false
+@@
+
+movs r15, #0x324
+
+====================
+
+@@ filename = "BIOS_BX_r0_Box5"
+@@ start = 52
+@@ fill = false
+@@
+
+movs r15, #0x324
+
+====================
+
+@@ filename = "BIOS_BX_r0_Box10"
+@@ start = 88
+@@ fill = false
+@@
+
+movs r15, #0x324
+
+====================
+
+@@ filename = "BIOS_BX_lr_Box2"
+@@ start = 16
+@@ fill = false
+@@
+
+movs r15, #0x354
+
+====================
+
+@@ filename = "BIOS_BX_lr_Box5"
+@@ start = 52
+@@ fill = false
+@@
+
+movs r15, #0x354
+
+====================
+
+@@ filename = "BIOS_BX_lr_Box10"
+@@ start = 88
+@@ fill = false
+@@
+
+movs r15, #0x354
+
+====================
+
+@@ filename = "BIOS_BX_lr_Box2_Grab"
+@@ start = 12
+@@ fill = false
+@@
+
+mov r0, #0
+movs r15, #0x354
+
+====================
+
+@@ filename = "BIOS_BX_lr_Box5_Grab"
+@@ start = 48
+@@ fill = false
+@@
+
+mov r0, #0
+movs r15, #0x354
+
+====================
+
+@@ filename = "BIOS_BX_lr_Box10_Grab"
+@@ start = 84
+@@ fill = false
+@@
+
+mov r0, #0
+movs r15, #0x354
+
+====================
+
 @@ filename = "Bootstrapped"
 @@ start = 116
 @@


### PR DESCRIPTION
Added a bunch of exit codes for jumping into a bunch of ROM addresses. These include:

- BIOS BX r0 (0x324).
- BIOS BX lr (0x354).
- BIOS BX lr (0x354) with extra instruction for grab ACE.
- ROM BX r0 (various addresses depending on game and language).
- ROM BX lr (various addresses depending on game and language).
- BIOS BX lr (0x354) with extra instruction for grab ACE.

I have added versions of these exits that start at Box 2, Box 6, and finally Box 10.

Edit: the issue with CodeGenerator has been fixed, thus the note about the exit code bug is no longer needed.