### PR TITLE
Some Code Additions/Modifications

### DIFF
--- a/files_frlg/list.json
+++ b/files_frlg/list.json
@@ -34,6 +34,17 @@
     "game": ["fr", "lg"],
     "cat": ["rng"]
   },
+    {
+    "name": "Replace TID with SID",
+    "eng1": "misc/copySIDtoTID.txt",
+    "eng0": "misc/copySIDtoTID.txt",
+    "fra": "misc/copySIDtoTID.txt",
+    "ger": "misc/copySIDtoTID.txt",
+    "spa": "misc/copySIDtoTID.txt",
+    "ita": "misc/copySIDtoTID.txt",
+    "game": ["fr", "lg"],
+    "cat": ["misc"]
+  },
   {
     "name": "Change TID and SID (move ACE)",
     "eng1": "rng/tidsid_moveACE.txt",

--- a/files_frlg/list.json
+++ b/files_frlg/list.json
@@ -234,6 +234,17 @@
     "game": ["fr", "lg"],
     "cat": ["misc"]
   },
+    {
+    "name": "Replace Pokemon OT w/ Trainer Name (bootstrapped)",
+    "eng1": "pkmn/ReplacePokemonOT.txt",
+    "eng0": "pkmn/ReplacePokemonOT.txt",
+    "fra": "pkmn/ReplacePokemonOT.txt",
+    "ger": "pkmn/ReplacePokemonOT.txt",
+    "spa": "pkmn/ReplacePokemonOT.txt",
+    "ita": "pkmn/ReplacePokemonOT.txt",
+    "game": ["fr", "lg"],
+    "cat": ["pkmn"]
+  },
   {
     "name": "Start wild battle with any Pokemon",
     "eng1": "pkmn/StartWildBattleWithAnyPokemon.txt",

--- a/files_frlg/misc/CopySIDtoTID.txt
+++ b/files_frlg/misc/CopySIDtoTID.txt
@@ -1,15 +1,14 @@
-@@ title = "Replace TID with SID"
+@@ title = "Replace TID with SID (Grab ACE)"
 @@ author = "Papa Jefe"
 @@ exit = "GrabACEExit"
 
-; Check Trainer Card after execution to quickly learn your Secret ID.
-; Use "Read Pokemon TID/SID" to check Secret ID of traded Pokemon from other games.
- 
+; Check Trainer Card after execution to quickly learn Secret ID.
 ; Reset game to restore original Trainer ID.
+
 ; After running, hatched Eggs made via "Create Egg from nothing" will always be Shiny.
 
 @@
 
 sbc r12, r15, #0xd100
-ldrh r11, [r12, #0x34]
+ldrh r11, [r12, #0x33]
 strh r11, [r12, #0x32]

--- a/files_frlg/misc/CopySIDtoTID.txt
+++ b/files_frlg/misc/CopySIDtoTID.txt
@@ -1,0 +1,15 @@
+@@ title = "Replace TID with SID"
+@@ author = "Papa Jefe"
+@@ exit = "GrabACEExit"
+
+; Check Trainer Card after execution to quickly learn your Secret ID.
+; Use "Read Pokemon TID/SID" to check Secret ID of traded Pokemon from other games.
+ 
+; Reset game to restore original Trainer ID.
+; After running, hatched Eggs made via "Create Egg from nothing" will always be Shiny.
+
+@@
+
+sbc r12, r15, #0xd100
+ldrh r11, [r12, #0x34]
+strh r11, [r12, #0x32]

--- a/files_frlg/pkmn/Create6IVEgg.txt
+++ b/files_frlg/pkmn/Create6IVEgg.txt
@@ -2,38 +2,69 @@
 @@ author = "PapaJefe & Adrichu00"
 @@ exit = "GrabACEExit"
 
-; This creates a hatchable Egg of any species, with 31 IVs in every stat in Box 9 Slot 27.
-; Make sure Box 9 Slot 27 is empty beforehand.
-; PID and OTID will both be 0x00000000, so Nature is always Hardy, and Ability is always 0.
-; If using ability = 1, the Pokemon created in Box 9 Slot 27 won't be an Egg (at first).
+; ~STEP 1: SELECT SPECIES~
+; This code will create an Egg with the species of your choice in Box 10 Slot 2.
+; Make sure Box 10 Slot 2 is empty beforehand.
+; Type in species name below, and select from the dropdown to select its Index Number.
+
+species = POKEMON @input:species
+
+;~STEP 2: SELECT ABILITY~
+; ability = 0 is First Ability (Ex. Staryu: Illuminate)
+; ability = 1 is Second Ability (Ex. Staryu: Natural Cure)
+; NOTE!: ability=1 won't appear until after hatching.
+
+ability = 0
+
+;~STEP 3: CHOOSE ORIGIN GAME~
+; Alternate game origin will be preserved upon hatching. All other Met Data will self correct.
+; Emerald=0x29C0, FireRed=0x0A30, LeafGreen=0x02A4, Ruby=0xA100, Sapphire=0x2880 , XDColo=0x2FC0
+
+met_data ?= 0x29C0
+
+;~STEP 4: GENERATE & EXECUTE CODE~
+; If ability=0 an Egg will appear in Box 10 Slot 2.
+; If ability=1 a Lvl 0 Shiny of your chosen Pokemon will appear.
+; Move the Egg/Pokemon to Box 3 Slot 1.
+
+;~STEP 5: CHOOSE PID for NATURE/ABILITY~
+; The PID and OTID will be 0x00000000, so Nature is always Hardy and Ability is 0.
 ; You can change Nature/Ability by combining with the Mail Glitch.
-;
-; After execution, move the Egg/Pokemon to Box 3 Slot 1.
-;
+
 ; Choose ONE word that matches your desired Nature/Ability from this list:
 ; https://e-sh4rk.github.io/EmeraldACE_web/doc/naturewords.txt
-;
-; Activate the Glitched Mail Message, and enter the same word into the first four slots.
-;
+
 ; For example, Adamant/Ability 0 would be:
+; GAEM Adamant	1800	LIFESTYLE	CHORES
+
+; Adamant/Ability 1 would be:
+; GAME Adamant	1C01	TIME	MORNING
+
+; Activate the Glitched Mail Message, and enter the chosen word into the first four slots.
+
+; ~EXAMPLE MAIL MESSAGE~
 ; CHORES CHORES
 ; CHORES CHORES
-;
-; After entering the words, hatch the Egg.
 
+; The Egg's PID is now 0x1800 1800
+; If ability=0, nothing about the Egg should visibly change.
+; If ability=1, the Lvl 0 Shiny Pokemon should become an Egg.
 
-species = 0x003F ; @input:species
-ability = 0 ; Either 0 or 1
+;~STEP 6: HATCH THE EGG~
+; Egg should contain desired Pokemon with chosen IVs, Nature & Ability.
+; If used after executing "Replace TID with SID," all Eggs generated this way will be Shiny.
 
+; Don't touch these variables.
+IVs = 0xFFFFFFFF
+Checksum ? = ((IVs & 0xFFFF) + (IVs >> 16) + species + met_data)
 @@
 
-sbc r11, pc, 0x3040 ; Offset for Box 9 Slot 27
-sbc r10, pc, 0x30C0
-mov r12, {species} ? ; Store Species in r12
-strh r12, [r11, 0x38] ; Write Species
-mov r12, 0xFFFFFFFF ? ; Store IVs in R12
-str r12, [r10, {ability? 0xD2: 0xDE}]! ; Write IVs
-mov r12, 0x02a4 ? ; Store Origin Data
-strh r12, [r11, {ability? 0x52:0x5E}] ; Write Origin Data
-mov r12, {species + 0x02A2} ? ; calc Checksum
-strh r12, [r11, 0x34] ; store Checksum
+SBC r11, pc, #0x2F00
+MOV r12, {species} ?
+STRH r12, [r11, #0x88] ; Store species
+MOV r12, {met_data} ?
+STRH r12, [r11, #{ability ? 0xA2 : 0xAE}] ; Store origin data
+MOV r12, {Checksum} ?
+STRH r12, [r11, #0x84] ; Store checksum
+MOV r12, {IVs} ?
+STR r12, [r11, #{ability ? 0xA4 : 0xB0}]! ; Store IVs

--- a/files_frlg/pkmn/Create6IVEgg.txt
+++ b/files_frlg/pkmn/Create6IVEgg.txt
@@ -56,7 +56,7 @@ met_data ?= 0x29C0
 
 ; Don't touch these variables.
 IVs = 0xFFFFFFFF
-Checksum ? = ((IVs & 0xFFFF) + (IVs >> 16) + species + met_data)
+Checksum ? = ((IVs & 0xFFFF) + (IVs >> 16) + species + met_data) & 0xFFFF
 @@
 
 SBC r11, pc, #0x2F00

--- a/files_frlg/pkmn/HiddenPowerEgg.txt
+++ b/files_frlg/pkmn/HiddenPowerEgg.txt
@@ -70,7 +70,7 @@ met_data ?= 0x29C0
 ; If used after executing "Replace TID with SID," all Eggs generated this way will be Shiny.
 
 ; Don't touch this variable.
-Checksum ? = ((IVs & 0xFFFF) + (IVs >> 16) + species + met_data)
+Checksum ? = ((IVs & 0xFFFF) + (IVs >> 16) + species + met_data) & 0xFFFF
 @@
 
 SBC r11, pc, #0x2F00

--- a/files_frlg/pkmn/HiddenPowerEgg.txt
+++ b/files_frlg/pkmn/HiddenPowerEgg.txt
@@ -2,43 +2,81 @@
 @@ author = "PapaJefe & it_is_final"
 @@ exit = "Bootstrapped"
 
+; ~REQUIREMENTS~
 ; This code requires a Box 14 exit code for grab ACE.
 ; It can be found here:
 ; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
-;
+
+; Once the Bootstrap is set up, follow the instructions below.
+
+; ~STEP 1: SELECT SPECIES~
 ; This code will create an Egg with the species of your choice in Box 10 Slot 2.
 ; Make sure Box 10 Slot 2 is empty beforehand.
-; If using ability = 1, the result will be a Pokemon, rather than an Egg (at first).
-;
-; Replace the IVs variable below with the Hex value for desired IVs.
+; Type in species name below, and select from the dropdown to select its Index Number.
+
+species = POKEMON @input:species
+
+;~STEP 2: SELECT ABILITY~
+; ability = 0 is First Ability (Ex. Staryu: Illuminate)
+; ability = 1 is Second Ability (Ex. Staryu: Natural Cure)
+; NOTE!: ability=1 won't appear until after hatching.
+
+ability = 0
+
+;~STEP 3: CHOOSE IVs~
 ; You can find a list of compatible Hex values for IVs here:
 ; https://e-sh4rk.github.io/EmeraldACE_web/doc/HiddenPowerHex.txt
-;
-; The PID and OTID will be 0x00000000, so nature is always Hardy and Ability is 0.
+
+; Replace the IVs variable below with the Hex value for desired IVs.
+
+IVs = 0xFDFFFFFF
+
+;~STEP 4: CHOOSE ORIGIN GAME~
+; Alternate game origin will be preserved upon hatching. All other Met Data will self correct.
+; Emerald=0x29C0, FireRed=0x0A30, LeafGreen=0x02A4, Ruby=0xA100, Sapphire=0x2880 , XDColo=0x2FC0
+
+met_data ?= 0x29C0
+
+;~STEP 5: GENERATE & EXECUTE CODE~
+; If ability=0 an Egg will appear in Box 10 Slot 2.
+; If ability=1 a Lvl 0 Shiny of your chosen Pokemon will appear.
+; Move the Egg/Pokemon to Box 3 Slot 1.
+
+;~STEP 6: CHOOSE PID for NATURE/ABILITY~
+; The PID and OTID will be 0x00000000, so Nature is always Hardy and Ability is 0.
 ; You can change Nature/Ability by combining with the Mail Glitch.
-;
-; After execution, move the Egg/Pokemon to Box 3 Slot 1.
-;
+
 ; Choose ONE word that matches your desired Nature/Ability from this list:
 ; https://e-sh4rk.github.io/EmeraldACE_web/doc/naturewords.txt
-; Activate the Glitched Mail Message, and enter the chosen word into the first four slots.
-;
-; For example, Adamant/Ability 0 would be:
-; CHORES CHORES
-; CHORES CHORES
-;
-; After entering the words, hatch the Egg.
 
-species = 306 @input:species
-ability = 0
-IVs = 0xFDFFFFFF
-Checksum ? = ((IVs & 0xFFFF) + (IVs >> 16) + species + 0x0180)
+; For example, Adamant/Ability 0 would be:
+; GAEM Adamant	1800	LIFESTYLE	CHORES
+
+; Adamant/Ability 1 would be:
+; GAME Adamant	1C01	TIME	MORNING
+
+; Activate the Glitched Mail Message, and enter the chosen word into the first four slots.
+
+; ~EXAMPLE MAIL MESSAGE~
+; CHORES CHORES
+; CHORES CHORES
+
+; The Egg's PID is now 0x1800 1800
+; If ability=0, nothing about the Egg should visibly change.
+; If ability=1, the Lvl 0 Shiny Pokemon should become an Egg.
+
+;~STEP 7: HATCH THE EGG~
+; Egg should contain desired Pokemon with chosen IVs, Nature & Ability.
+; If used after executing "Replace TID with SID," all Eggs generated this way will be Shiny.
+
+; Don't touch this variable.
+Checksum ? = ((IVs & 0xFFFF) + (IVs >> 16) + species + met_data)
 @@
 
 SBC r11, pc, #0x2F00
 MOV r12, {species} ?
 STRH r12, [r11, #0x88] ; Store species
-MOV r12, 0x0180 ?
+MOV r12, {met_data} ?
 STRH r12, [r11, #{ability ? 0xA2 : 0xAE}] ; Store origin data
 MOV r12, {Checksum} ?
 STRH r12, [r11, #0x84] ; Store checksum

--- a/files_frlg/pkmn/ReadOTIDfromPartySlot4toPartySlot3.txt
+++ b/files_frlg/pkmn/ReadOTIDfromPartySlot4toPartySlot3.txt
@@ -2,7 +2,10 @@
 @@ author = "Papa Jefe & im a blisy"
 @@ exit = "GrabACEExit" // Use "CommonExit" for move ACE.
 
-; Store the TID/SID of the 4th Slot Party Pokemon in the Atk thru SpDef of the 3rd Pokemon.
+; Allows user to check the Secret ID of traded Pokemon from other games.
+; Use "Replace TID with SID" to check personal Secret ID faster.
+
+; Stores the TID/SID of the 4th Slot Party Pokemon in the Atk thru SpDef of the 3rd Pokemon.
 ; Pokemon in 3rd Party Slot must have no stats bigger than 2 digits. 
 ; Stat changes will reverse themselves after depositing to the PC.
 

--- a/files_frlg/pkmn/ReplacePokemonOT.txt
+++ b/files_frlg/pkmn/ReplacePokemonOT.txt
@@ -1,0 +1,20 @@
+@@ title = "Replace Pokemon OT with Your OT"
+@@ author = "Papa Jefe"
+@@ exit = "Bootstrapped"
+
+; Replaces the OT Name of the Pokemon in Box 10 Slot 2, with your OT Name
+
+
+@@
+
+sbc r12, r15, #0xD108 ? ; offset for OT Name
+sbc r10, pc, #0x2F10 ? ; offset for Box 10 Slot 2
+ldrh r11, [r12, #0x2F] ; Load 1st OT Halfword
+strh r11, [r10, #0x80] ; Store 1st OT Halfword
+ldrh r11, [r12, #0x31] ; Load 2nd OT Halfword
+strh r11, [r10, #0x82] ; Store 2nd OT Halfword
+ldrh r11, [r12, #0x33] ; Load 3rd OT Halfword
+strh r11, [r10, #0x84] ; Store 3rd OT Halfword
+ldrh r11, [r12, #0x35] ; Load 4th OT Halfword
+bic r11, r11, 0xFF00 ; Fix Marking Data
+strh r11, [r10, #0x85] ; Store 4th OT Halfword


### PR DESCRIPTION
- Updated 6IV Egg/Hidden Power Egg codes to allow for custom origin game.
- Added step-by-step instructions to those codes for easier end-user experience.
- Added "Replace TID with SID" for quick SID checking (@claydolwithexplosion suggestion)
- Alter text in "Read OTID from Party Slot" code to clarify its only needed for checking SIDs from other saves.
- Added "Replace Pokemon OT with Trainer Name," which is useful for fixing generated Pokemon.

Have tested all of them myself, and they all use pc-relative addresses so they should be language\version agnostic.
