### PR TITLE
GlobalScriptContext code

### DIFF
--- a/files/list.json
+++ b/files/list.json
@@ -483,6 +483,15 @@
     "cat": ["misc"]
   },
   {
+    "name": "Run script via GlobalScriptContext",
+    "eng": "misc/RunScriptViaGlobalScriptContext.txt",
+    "fra": "misc/RunScriptViaGlobalScriptContext.txt",
+    "ger": "misc/RunScriptViaGlobalScriptContext.txt",
+    "spa": "misc/RunScriptViaGlobalScriptContext.txt",
+    "ita": "misc/RunScriptViaGlobalScriptContext.txt",
+    "cat": ["misc"]
+  },
+  {
     "name": "Mass Clone/Declone Pokémon (for 0x085F)",
     "jap": "misc/MassClonePokemonJAPThumb.txt",
     "cat": ["misc"]

--- a/files/misc/RunScriptViaGlobalScriptContext.txt
+++ b/files/misc/RunScriptViaGlobalScriptContext.txt
@@ -1,0 +1,42 @@
+@@ title = "Run script via GlobalScriptContext"
+@@ author = "final and Mettrich"
+@@ exit = "ROM_BX_lr_Box10_Sprite"
+@@ filler4 = 0xffffffff
+
+// The default exit code set for this code will leave you on the summary
+// screen.
+//
+// For metastable species such as 0x40ed, 0x415e, or 0x599, make sure that
+// you view the summary of an adjacent Pokémon, switch to the statistics,
+// moves, or contest moves page, then switch to the ACE species’ summary.
+//
+// Alternatively you can also use a different exit code such as
+// "Certificate", "WhiteOut" or "Bootstrapped" instead.
+
+// This code inserts a custom script pointer into the global script
+// context (and also sets some other stuff) that will run as soon as
+// you return to the overworld.
+//
+// Script addresses from "Change ObjectEvent Script Pointer" should work here.
+//
+// Trigger ACE, then return to the overworld. The script should run
+// immediately.
+
+script_address = 0x0
+
+@@
+
+; `ctx` refers to sGlobalScriptContext
+
+MOV     r10, #0x3000000                 ; IWRAM addressing part 1
+SBCGT   r10, r10, r10, ASR #17          ; r10 = 0x2fffe7f, address part 2
+BIC     r10, r10, #0xfc000003           ; r10 = 0x2fffe7c, address part 3
+
+ADC     r12, r10, #0x284                ; r12 = 0x3000100, mode=SCRIPT_MODE_BYTECODE, stackDepth=0
+
+STRB    r12, [r10, #0xfbc]!             ; Store CONTEXT_RUNNING in sGlobalScriptContextStatus
+
+STRH    r12, [r10, #8]                  ; Store in ctx->stackDepth, and ctx->mode
+
+MOV     r12, #{script_address} ?
+STR     r12, [r10, r14, ASR #23]!       ; Store in ctx->scriptPtr (r10 + 16)

--- a/files_frlg/misc/RunScriptViaGlobalScriptContext.txt
+++ b/files_frlg/misc/RunScriptViaGlobalScriptContext.txt
@@ -1,28 +1,31 @@
 @@ title = "Run script via GlobalScriptContext"
 @@ author = "final and Mettrich"
-@@ exit = "GrabACEExit"
+@@ exit = "ROM_BX_lr_Box10_Grab"
+@@ filler4 = 0xffffffff
 
 // This code inserts a custom script pointer into the global script
 // context (and also sets some other stuff) that will run as soon as
-// you leave Bill’s PC in a Pokémon Center or in the Daycare.
+// you return to the overworld.
 //
 // Script addresses from "Run script via NPC" should work here.
 //
-// Trigger ACE, then leave the boxes, and then exit the menu, the
-// script should run.
+// Trigger ACE, then return to the overworld. The script should run
+// immediately.
 
 script_address = 0x0
 
 @@
 
-MOV r10, #0x3000000  ; Prepare sGlobalScriptContextStatus address part 1
-MOV r11, #0x2e0  ; Prepare stackDepth, and mode part 1
-BIC r12, r10, #0xff000000  ; r12 = 0
-SBC r11, #0xde  ; r11 = 0x0201, prepare stackDepth, and mode part 2
+; `ctx` refers to sGlobalScriptContext
 
-STRB r12, [r10, #0xea8]!  ; Store RUNNING status in sGlobalScriptContextStatus, address part 2
-STRH r11, [r10, #8]!  ; Store in sGlobalScriptContext->stackDepth, and sGlobalScriptContext->mode
-STR r12, [r10, lr, ASR #25]!  ; Store in sGlobalScriptContext->nativePtr
+MOV     r10, #0x3000000                 ; IWRAM addressing
 
-MOV r12, {script_address} ?
-STR r12, [r10, lr, ASR #25]!  ; Store in sGlobalScriptContext->scriptPtr
+MOV     r11, #0xbd00
+BIC     r11, r11, #0x3fc00              ; r11 = 0x100, mode=SCRIPT_MODE_BYTECODE, stackDepth=0
+
+STRB    r11, [r10, #0xea8]!             ; Store CONTEXT_RUNNING in sGlobalScriptContextStatus
+
+STRH    r11, [r10, #8]!                 ; Store in ctx->stackDepth, and ctx->mode
+
+MOV     r12, #{script_address} ?
+STR     r12, [r10, r11, ASR #5]!        ; Store in ctx->scriptPtr (r10 + 8)

--- a/files_frlg/misc/Warp.txt
+++ b/files_frlg/misc/Warp.txt
@@ -1,4 +1,4 @@
-@@ title = "Teleport anywhere (Bootstrapped)"
+@@ title = "Teleport anywhere"
 @@ author = "final, Theocatic and Mettrich"
 @@ exit = "Bootstrapped"
 @@ filler4 = 0xffffffff
@@ -7,8 +7,7 @@
 // It can be found here:
 // https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
-// Talk to the designated NPC to perform the teleportation after
-// executing this code.
+// The teleportation will occur as soon as you log off Bill’s PC.
 
 // The map list can be found here:
 // https://pastebin.com/peDhNbEt
@@ -21,37 +20,33 @@ map_id = 3
 
 warp = 0
 
-// `npc` determines the NPC that will execute the custom script.
-// Default value `1` corresponds to the Pokémon Center Nurse in
-// all Pokémon Centers, or the man in the Route 5 daycare.
-
-npc = 1
-
 // Leave these values at 0 if you are using any `warp` value other
 // than 0xff.
 
 x = 0
 y = 0
 
-// `aligned_pc` should be set to 1 if you are using species 0x0351 on an old emulator, or using alternate ACE species that enter the boxes with an aligned PC (entrypoint % 2 == 0).
-
 // Do not touch the below variables
+
+// Teleport script:
+//
+// 39 BB MM WW xx xx yy yy warp 0xBB 0xMM 0xWW 0xXXXX 0xYYYY
+// 02 end
 
 script0 = ((warp & 0xff) << 24) | ((map_id & 0xffff) << 8) | 0x39
 script1 = ((y & 0xffff) << 16) | (x & 0xffff)
-npc_offset = 0x1A5 + (npc * 0x18) + 0x400  // 0x400 added to avoid quote characters
 
 @@
 
-SBC r10, pc, 0xBE00
-ADC r11, r4, #0x300  ; Prepare script pointer (within gSaveDataBuffer)
-STR r11, [r10, {npc_offset}]!
+MOV     r12, #0x3000000             ; sGlobalScriptContext addressing
+ADC     r11, r4, #0x300             ; Prepare script pointer (within gSaveDataBuffer)
+STR     r11, [r12, #0xeb8]!         ; Store pointer in sGlobalScriptContext->scriptPtr
 
-MOV r12, {script0} ?5  ; Move in script part 1
-STR r12, [r11, #0]!  ; Store script part 1
+MOV     r12, #{script0} ?5
+STR     r12, [r11, #0]!             ; Store script part 1
 
-MOV r12, {script1} ?5  ; Move in script part 2
-STR r12, [r11, lr, ASR #25]!  ; Store script part 2
+MOV     r12, #{script1} ?5
+STR     r12, [r11, lr, ASR #25]!    ; Store script part 2
 
-MOV r12, #0xfc000002  ; Not needed for NPCs, but if using this for setting up script for GlobalScriptContext, then it is needed due to GlobalScriptContext continuing to execute past 0x39.
-STRB r12, [r11, lr, ASR #25]  ; Store script part 3
+MOV     r12, #0xfc000002
+STRB    r12, [r11, lr, ASR #25]     ; Store script end

--- a/files_frlg/rng/SeedChangeAndWarpBootstrappedEN.txt
+++ b/files_frlg/rng/SeedChangeAndWarpBootstrappedEN.txt
@@ -1,34 +1,52 @@
-@@ title = "Change PRNG seed and teleport (Bootstrapped, EN)"                			
-@@ author = "Theocatic / final"				
+@@ title = "Change PRNG seed and teleport (EN)"
+@@ author = "final, Theocatic and Mettrich"
 @@ exit = "Bootstrapped"
+@@ filler4 = 0xffffffff
 
-; This code requires a Box 14 exit code for grab ACE.
-; It can be found here:
-; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+// This code requires a Box 14 exit code for grab ACE.
+// It can be found here:
+// https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
-;this code will set PRNG to the desired seed when executed. Talk to the NPC you set in the map to warp afterwards. Best ran in the daycare
+// The teleportation will occur as soon as you log off Bill’s PC.
+// This code is best ran in the Route 5 Daycare.
 
+// The map list can be found here:
+// https://pastebin.com/peDhNbEt
 
-;Map Bank and Map ID values can be found here https://pastebin.com/peDhNbEt
+map_id = 0x0003
 
-DesiredSeed = 0x1234ABCD
+// `warp` determines which warp point you will teleport to.
+// Use warp 3 for Zapdos
 
-npc_id = 1 ;Sets which NPC on the map to run the script through.
+warp = 0
 
-map_id = 0x3802
+// Input the desired RNG state here
 
-warp = 0 ;Change this to change which entrance you teleport to. Use Warp 3 for Zapdos
+seed = 0x1234abcd
 
-script0 = (warp << 24) | ((map_id & 0xffff) << 8) | 0x39
-npc_offset = 0x1A5 + (npc_id * 0x18) + 0x400  ; 0x400 added to avoid quote characters
+// Do not touch the below variables
 
-@@                
+// Teleport script:
+//
+// 39 YY XX WW 00 00 00 00 warp 0xYY 0xXX 0xWW
+// FF @ illegal command, terminates script execution
 
-sbc r10, pc, 0xBE00
-adc r11, r4, 0x300
-str r11, [r10, {npc_offset}]!
-mov r12, {script0} ?
-str r12, [r11]!
-mov r12, {DesiredSeed} ?
-BIC r11, r13, #0x2F00 ;sets r11 to 0x03005000 gRNGValue
-str r12, [r11]!
+script = ((warp & 0xff) << 24) | ((map_id & 0xffff) << 8) | 0x39
+
+@@
+
+MOV     r12, #0x3000000         ; sGlobalScriptContext addressing
+ADCS    r11, r12, #0xc300       ; gRngValue addressing
+
+ADC     r10, r4, #0xff0         ; Prepare script pointer (within gSaveDataBuffer)
+STR     r10, [r12, #0xeb8]!     ; Store pointer in sGlobalScriptContext->scriptPtr
+
+MOV     r12, #{script} ?5       ; Move script
+STR     r12, [r10, #0]!         ; Store script
+
+0xe3ffcccc                      ; MVNS r12, #0xcc00
+STRH    r12, [r10, #8]          ; Store script end
+ADCS    r11, r11, #0xc50        ; r11 = &gRngValue - 0xb0, fix CPSR
+
+MOV     r12, #{seed} ?5
+STR     r12, [r11, #0xb0]!      ; Store seed in gRngValue

--- a/files_frlg/rng/SeedChangeAndWarpBootstrappedEU.txt
+++ b/files_frlg/rng/SeedChangeAndWarpBootstrappedEU.txt
@@ -1,35 +1,52 @@
-@@ title = "Change PRNG seed and teleport (Bootstrapped, EU)"                			
-@@ author = "Theocatic / final"				
+@@ title = "Change PRNG seed and teleport (EU)"
+@@ author = "final, Theocatic and Mettrich"
 @@ exit = "Bootstrapped"
+@@ filler4 = 0xffffffff
 
-; This code requires a Box 14 exit code for grab ACE.
-; It can be found here:
-; https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+// This code requires a Box 14 exit code for grab ACE.
+// It can be found here:
+// https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
 
-;this code will set PRNG to the desired seed when executed. Talk to the NPC you set in the map to warp afterwards. Best ran in the daycare
+// The teleportation will occur as soon as you log off Bill’s PC.
+// This code is best ran in the Route 5 Daycare.
 
+// The map list can be found here:
+// https://pastebin.com/peDhNbEt
 
-;Map Bank and Map ID values can be found here https://pastebin.com/peDhNbEt
+map_id = 0x0003
 
-DesiredSeed = 0x1234ABCD
+// `warp` determines which warp point you will teleport to.
+// Use warp 3 for Zapdos
 
-npc_id = 1 ;Sets which NPC on the map to run the script through.
+warp = 0
 
-map_id = 0x3802
+// Input the desired RNG state here
 
-warp = 0 ;Change this to change which entrance you teleport to. Use Warp 3 for Zapdos
+seed = 0x1234abcd
 
-script0 = (warp << 24) | ((map_id & 0xffff) << 8) | 0x39
-npc_offset = 0x1A5 + (npc_id * 0x18) + 0x400  ; 0x400 added to avoid quote characters
+// Do not touch the below variables
 
-@@                
+// Teleport script:
+//
+// 39 YY XX WW 00 00 00 00 warp 0xYY 0xXX 0xWW
+// FF @ illegal command, terminates script execution
 
-sbc r10, pc, 0xBE00
-adc r11, r4, 0x300
-str r11, [r10, {npc_offset}]!
-mov r12, {script0} ?
-str r12, [r11]!
-mov r12, {DesiredSeed} ?
-BIC r11, r13, #0x2F00 ;sets r11 to 0x03005000 gRNGValue
-SBC r11, r11, #0xB0
-str r12, [r11, lr, asr #27]!
+script = ((warp & 0xff) << 24) | ((map_id & 0xffff) << 8) | 0x39
+
+@@
+
+MOV     r12, #0x3000000         ; sGlobalScriptContext addressing
+ADCS    r11, r12, #0xc300       ; gRngValue addressing
+
+ADC     r10, r4, #0xff0         ; Prepare script pointer (within gSaveDataBuffer)
+STR     r10, [r12, #0xeb8]!     ; Store pointer in sGlobalScriptContext->scriptPtr
+
+MOV     r12, #{script} ?5       ; Move script
+STR     r12, [r10, #0]!         ; Store script
+
+0xe3ffcccc                      ; MVNS r12, #0xcc00
+STRH    r12, [r10, #8]          ; Store script end
+ADCS    r11, r11, #0xc50        ; r11 = &gRngValue, fix CPSR
+
+MOV     r12, #{seed} ?5
+STR     r12, [r11, #0]!         ; Store seed in gRngValue

--- a/files_rs/list.json
+++ b/files_rs/list.json
@@ -156,7 +156,23 @@
     "cat": ["bootstraps"]
   },
   {
-    "name": "Change PRNG seed and teleport",
+    "name": "Teleport anywhere (Grab ACE)",
+    "eng2": "rng/Warp_Grab.txt",
+    "eng1": "rng/Warp_Grab.txt",
+    "eng0": "rng/Warp_Grab.txt",
+    "fra1": "rng/Warp_Grab.txt",
+    "fra0": "rng/Warp_Grab.txt",
+    "ger1": "rng/Warp_Grab.txt",
+    "ger0": "rng/Warp_Grab.txt",
+    "spa1": "rng/Warp_Grab.txt",
+    "spa0": "rng/Warp_Grab.txt",
+    "ita1": "rng/Warp_Grab.txt",
+    "ita0": "rng/Warp_Grab.txt",
+    "game": ["ruby", "sapp"],
+    "cat": ["rng"]
+  },
+  {
+    "name": "Change PRNG seed and teleport (Move ACE)",
     "eng2": "rng/SeedChangeAndWarpENG.txt",
     "eng1": "rng/SeedChangeAndWarpENG.txt",
     "eng0": "rng/SeedChangeAndWarpENG.txt",
@@ -170,6 +186,22 @@
     "ita0": "rng/SeedChangeAndWarpEU.txt",
     "jap0": "rng/SeedChangeAndWarpJP.txt",
     "jap1": "rng/SeedChangeAndWarpJP.txt",
+    "game": ["ruby", "sapp"],
+    "cat": ["rng"]
+  },
+  {
+    "name": "Change PRNG seed and teleport (Grab ACE)",
+    "eng2": "rng/SeedChangeAndWarpGrabEN.txt",
+    "eng1": "rng/SeedChangeAndWarpGrabEN.txt",
+    "eng0": "rng/SeedChangeAndWarpGrabEN.txt",
+    "fra1": "rng/SeedChangeAndWarpGrabEU.txt",
+    "fra0": "rng/SeedChangeAndWarpGrabEU.txt",
+    "ger1": "rng/SeedChangeAndWarpGrabEU.txt",
+    "ger0": "rng/SeedChangeAndWarpGrabEU.txt",
+    "spa1": "rng/SeedChangeAndWarpGrabEU.txt",
+    "spa0": "rng/SeedChangeAndWarpGrabEU.txt",
+    "ita1": "rng/SeedChangeAndWarpGrabEU.txt",
+    "ita0": "rng/SeedChangeAndWarpGrabEU.txt",
     "game": ["ruby", "sapp"],
     "cat": ["rng"]
   },

--- a/files_rs/list.json
+++ b/files_rs/list.json
@@ -268,5 +268,21 @@
     "ita0": "misc/ChangeVar.txt",
     "game": ["ruby", "sapp"],
     "cat": ["misc"]
+  },
+  {
+    "name": "Run script via ScriptContext1",
+    "eng2": "misc/RunViaScriptContext1.txt",
+    "eng1": "misc/RunViaScriptContext1.txt",
+    "eng0": "misc/RunViaScriptContext1.txt",
+    "fra1": "misc/RunViaScriptContext1.txt",
+    "fra0": "misc/RunViaScriptContext1.txt",
+    "ger1": "misc/RunViaScriptContext1.txt",
+    "ger0": "misc/RunViaScriptContext1.txt",
+    "spa1": "misc/RunViaScriptContext1.txt",
+    "spa0": "misc/RunViaScriptContext1.txt",
+    "ita1": "misc/RunViaScriptContext1.txt",
+    "ita0": "misc/RunViaScriptContext1.txt",
+    "game": ["ruby", "sapp"],
+    "cat": ["misc"]
   }
 ]

--- a/files_rs/misc/RunViaScriptContext1.txt
+++ b/files_rs/misc/RunViaScriptContext1.txt
@@ -1,0 +1,29 @@
+@@ title = "Run script via ScriptContext1"
+@@ author = "final and Mettrich"
+@@ exit = "ROM_BX_lr_Box10_{LANG}_Grab"
+@@ filler4 = 0xffffffff
+
+// This code inserts a custom script pointer into the global script
+// context (and also sets some other stuff) that will run as soon as
+// you return to the overworld.
+//
+// Trigger ACE, then return to the overworld. The script should run
+// immediately.
+
+script_address = 0x0
+
+@@
+
+; `ctx` refers to ScriptContext1
+
+MOV     r10, #0x3000000                 ; IWRAM addressing
+
+MOV     r11, #0xbd00
+BIC     r11, r11, #0x3fc00              ; r11 = 0x100, mode=SCRIPT_MODE_BYTECODE, stackDepth=0
+
+STRB    r11, [r10, #0x5b0]!             ; Store CONTEXT_RUNNING in sScriptContext1Status
+
+STRH    r11, [r10, #8]!                 ; Store in ctx->stackDepth, and ctx->mode
+
+MOV     r12, #{script_address} ?
+STR     r12, [r10, r11, ASR #5]!        ; Store in ctx->scriptPtr (r10 + 8)

--- a/files_rs/misc/Warp_Grab.txt
+++ b/files_rs/misc/Warp_Grab.txt
@@ -1,0 +1,60 @@
+@@ title = "Teleport anywhere (Grab ACE)"
+@@ author = "final, Theocatic and Mettrich"
+@@ exit = "Bootstrapped"
+@@ filler4 = 0xffffffff
+
+// This code works with grab ACE, however 0x44fc control code ACE must
+// perform extra steps in order for this code to work. Specifically
+// the ACE must be triggered while you are in the PC.
+//
+// This code requires a Box 14 exit code for grab ACE.
+// It can be found here:
+// https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+//
+// Please note that the linked web page is for FireRed and LeafGreen but
+// the exit also works on Ruby and Sapphire. Substitute "STARS" with
+// "POLKA-DOT" or whatever the equivalent is in your language.
+
+// The teleportation will occur as soon as you log off the PC.
+
+// The map list can be found here:
+// https://pastebin.com/peDhNbEt
+
+map_id = 0x0000
+
+// `warp` determines which warp point you will teleport to.
+// Set this to 0xff if you want to control the exact coordinates you
+// want to warp to via the `x` and `y` variables.
+
+warp = 0
+
+// Leave these values at 0 if you are using any `warp` value other
+// than 0xff.
+
+x = 0
+y = 0
+
+// Do not touch the below variables
+
+// Teleport script:
+//
+// 39 BB MM WW xx xx yy yy warp 0xBB 0xMM 0xWW 0xXXXX 0xYYYY
+// 02 end
+
+script0 = ((warp & 0xff) << 24) | ((map_id & 0xffff) << 8) | 0x39
+script1 = ((y & 0xffff) << 16) | (x & 0xffff)
+
+@@
+
+MOV     r12, #0x3000000                 ; sGlobalScriptContext addressing
+SBC     r11, r12, #0xff                 ; Prepare script pointer (in unused EWRAM)
+STR     r11, [r12, #0xeb8]!             ; Store pointer in sGlobalScriptContext->scriptPtr
+
+MOV     r12, #{script0} ?5
+STR     r12, [r11, r14, ASR #25]!       ; Store script part 1
+
+MOV     r12, #{script1} ?5
+STR     r12, [r11, r14, ASR #25]!       ; Store script part 2
+
+MOV     r12, #0xfc000002
+STRB    r12, [r11, lr, ASR #25]         ; Store script end

--- a/files_rs/rng/SeedChangeAndWarpGrabEN.txt
+++ b/files_rs/rng/SeedChangeAndWarpGrabEN.txt
@@ -1,0 +1,58 @@
+@@ title = "Change PRNG seed and teleport (Grab ACE, EN)"
+@@ author = "final, Theocatic and Mettrich"
+@@ exit = "Bootstrapped"
+@@ filler4 = 0xffffffff
+
+// This code works with grab ACE, however 0x44fc control code ACE must
+// perform extra steps in order for this code to work. Specifically
+// the ACE must be triggered while you are in the PC.
+//
+// This code requires a Box 14 exit code for grab ACE.
+// It can be found here:
+// https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+//
+// Please note that the linked web page is for FireRed and LeafGreen but
+// the exit also works on Ruby and Sapphire. Substitute "STARS" with
+// "POLKA-DOT" or whatever the equivalent is in your language.
+
+// The teleportation will occur as soon as you log off the PC.
+
+// The map list can be found here:
+// https://pastebin.com/kmrbJY0S
+
+map_id = 0x0000
+
+// `warp` determines which warp point you will teleport to.
+
+warp = 0
+
+// Input the desired RNG state here
+
+seed = 0
+
+// Do not touch the below variables
+
+// Teleport script:
+//
+// 39 YY XX WW 00 00 00 00 warp 0xYY 0xXX 0xWW
+// FF @ illegal command, terminates script execution
+
+script = ((warp & 0xff) << 24) | ((map_id & 0xffff) << 8) | 0x39
+
+@@
+
+MOV     r12, #0x3000000                 ; sScriptContext1 addressing
+ADCS    r11, r12, #0xc500               ; gRngValue addressing
+
+SBC     r10, r12, #0xff0                ; Prepare script pointer (in unused EWRAM)
+STR     r10, [r12, #0x5c0]!             ; Store pointer in sScriptContext1->scriptPtr
+
+MOV     r12, #{script} ?5               ; Move script
+STR     r12, [r10, r14, ASR #25]!       ; Store script
+
+0xe3ffcccc                              ; MVNS r12, #0xcc00
+STRH    r12, [r10, #8]                  ; Store script end
+ADCS    r11, r11, #0x318                ; r11 = &gRngValue, fix CPSR
+
+MOV     r12, #{seed} ?5
+STR     r12, [r11, #0]!                 ; Store seed in gRngValue

--- a/files_rs/rng/SeedChangeAndWarpGrabEU.txt
+++ b/files_rs/rng/SeedChangeAndWarpGrabEU.txt
@@ -1,0 +1,58 @@
+@@ title = "Change PRNG seed and teleport (Grab ACE, EU)"
+@@ author = "final, Theocatic and Mettrich"
+@@ exit = "Bootstrapped"
+@@ filler4 = 0xffffffff
+
+// This code works with grab ACE, however 0x44fc control code ACE must
+// perform extra steps in order for this code to work. Specifically
+// the ACE must be triggered while you are in the PC.
+//
+// This code requires a Box 14 exit code for grab ACE.
+// It can be found here:
+// https://pomeg-letterbombers.github.io/pokemon-ace-notes/frlg/exit-codes/box-14-exit/
+//
+// Please note that the linked web page is for FireRed and LeafGreen but
+// the exit also works on Ruby and Sapphire. Substitute "STARS" with
+// "POLKA-DOT" or whatever the equivalent is in your language.
+
+// The teleportation will occur as soon as you log off the PC.
+
+// The map list can be found here:
+// https://pastebin.com/kmrbJY0S
+
+map_id = 0x0000
+
+// `warp` determines which warp point you will teleport to.
+
+warp = 0
+
+// Input the desired RNG state here
+
+seed = 0
+
+// Do not touch the below variables
+
+// Teleport script:
+//
+// 39 YY XX WW 00 00 00 00 warp 0xYY 0xXX 0xWW
+// FF @ illegal command, terminates script execution
+
+script = ((warp & 0xff) << 24) | ((map_id & 0xffff) << 8) | 0x39
+
+@@
+
+MOV     r12, #0x3000000                 ; sScriptContext1 addressing
+ADCS    r11, r12, #0xc500               ; gRngValue addressing
+
+SBC     r10, r12, #0xff0                ; Prepare script pointer (in unused EWRAM)
+STR     r10, [r12, #0x5c0]!             ; Store pointer in sScriptContext1->scriptPtr
+
+MOV     r12, #{script} ?5               ; Move script
+STR     r12, [r10, r14, ASR #25]!       ; Store script
+
+0xe3ffcccc                              ; MVNS r12, #0xcc00
+STRH    r12, [r10, #8]                  ; Store script end
+ADCS    r11, r11, #0x328                ; r11 = &gRngValue, fix CPSR
+
+MOV     r12, #{seed} ?5
+STR     r12, [r11, #0]!                 ; Store seed in gRngValue


### PR DESCRIPTION
This pull request does the following:

Emerald:

- Add "Run script via GlobalScriptContext"

Unfortunately Emerald's address for GlobalScriptContext is inconvenient enough that I cannot directly port the teleport codes from the other versions to Emerald.

FireRed and LeafGreen:

- Updates "Teleport anywhere" and "Change PRNG seed and teleport (Bootstrapped)" to utilise the fact that GlobalScriptContext is already running when you are using the PC and overwrite the script pointer, skipping the extra set up needed for GlobalScriptContext.
- Updates "Run script via GlobalScriptContext" to now use `SCRIPT_MODE_BYTECODE`, and stackDepth 0.

Ruby and Sapphire:

- Add "Run script via ScriptContext1", "Teleport anywhere (Grab ACE)", and "Change PRNG seed and teleport (Grab ACE)".

