### PR TITLE
Make MakeStartersReappear available for EU languages on Switch

### DIFF
--- a/files_frlg/list.json
+++ b/files_frlg/list.json
@@ -441,9 +441,13 @@
     "eng0": "misc/MakeStartersReappear.txt",
     "eng10": "misc/MakeStartersReappear.txt",
     "fra": "misc/MakeStartersReappear.txt",
+    "fra10": "misc/MakeStartersReappear.txt",
     "ger": "misc/MakeStartersReappear.txt",
+    "ger10": "misc/MakeStartersReappear.txt",
     "spa": "misc/MakeStartersReappear.txt",
+    "spa10": "misc/MakeStartersReappear.txt",   
     "ita": "misc/MakeStartersReappear.txt",
+    "ita10": "misc/MakeStartersReappear.txt",   
     "game": ["fr", "lg"],
     "cat": ["misc"]
   },


### PR DESCRIPTION
The code works as is on French Switch games, so it should also work for other EU languages without change.

French tested (both games), I propose expanding to the other 3 languages on Switch as well in this PR since the flags and variables have apparently not been changed for them either, though I could not test them myself.