### PR TITLE
Add Japanese 0xFFC9 Grab Ace Ports

### DIFF
--- a/files_frlg/list.json
+++ b/files_frlg/list.json
@@ -13,6 +13,13 @@
     "cat": ["rng"]
   },
   {
+    "name": "Change PRNG seed and teleport (Grab ACE)",
+    "jap0": "rng/SeedChangeAndWarpGRABJP0.txt",
+    "jap1": "rng/SeedChangeAndWarpGRABJP1.txt",
+    "game": ["fr", "lg"],
+    "cat": ["rng"]
+  },
+  {
     "name": "Change PRNG seed and teleport (Bootstrapped)",
     "eng1": "rng/SeedChangeAndWarpBootstrappedEN.txt",
     "eng0": "rng/SeedChangeAndWarpBootstrappedEN.txt",
@@ -41,6 +48,8 @@
     "spa10": "rng/tidsid.txt",
     "ita": "rng/tidsid.txt",
     "ita10": "rng/tidsid.txt",
+    "jap0": "rng/tidsidGRABJP0.txt",
+    "jap1": "rng/tidsidGRABJP1.txt",
     "game": ["fr", "lg"],
     "cat": ["rng"]
   },
@@ -84,6 +93,8 @@
     "spa10": "misc/ChangeTrainerGender.txt",
     "ita": "misc/ChangeTrainerGender.txt",
     "ita10": "misc/ChangeTrainerGender.txt",
+    "jap0": "misc/ChangeTrainerGenderGRABJP0.txt",
+    "jap1": "misc/ChangeTrainerGenderGRABJP1.txt",
     "game": ["fr", "lg"],
     "cat": ["misc"]
   },
@@ -375,6 +386,8 @@
     "spa10": "misc/CreateTradebackNPCSwitch.txt",
     "ita": "misc/CreateTradebackNPC.txt",
     "ita10": "misc/CreateTradebackNPCSwitch.txt",
+    "jap0": "misc/CreateTradebackNPCGRABJP0.txt",
+    "jap1": "misc/CreateTradebackNPCGRABJP1.txt",
     "game": ["fr", "lg"],
     "cat": ["misc"]
   },
@@ -407,6 +420,8 @@
     "spa10": "misc/AddItemWrongPocket.txt",
     "ita": "misc/AddItemWrongPocket.txt",
     "ita10": "misc/AddItemWrongPocket.txt",
+    "jap0": "misc/AddItemWrongPocketGRABJP0.txt",
+    "jap1": "misc/AddItemWrongPocketGRABJP1.txt",
     "game": ["fr", "lg"],
     "cat": ["misc"]
   },
@@ -811,6 +826,8 @@
     "spa10": "pkmn/MakeMonShiny_SWITCH.txt",
     "ita": "pkmn/MakeMonShiny.txt",
     "ita10": "pkmn/MakeMonShiny_SWITCH.txt",
+    "jap0": "pkmn/MakeMonShinyGRABJP0.txt",
+    "jap1": "pkmn/MakeMonShinyGRABJP1.txt",
     "game": ["fr", "lg"],
     "cat": ["pkmn"]
   }

--- a/files_frlg/list.json
+++ b/files_frlg/list.json
@@ -13,7 +13,7 @@
     "cat": ["rng"]
   },
   {
-    "name": "Change PRNG seed and teleport (Grab ACE)",
+    "name": "Change PRNG seed and teleport",
     "jap0": "rng/SeedChangeAndWarpGRABJP0.txt",
     "jap1": "rng/SeedChangeAndWarpGRABJP1.txt",
     "game": ["fr", "lg"],

--- a/files_frlg/misc/AddItemWrongPocketGRABJP0.txt
+++ b/files_frlg/misc/AddItemWrongPocketGRABJP0.txt
@@ -1,0 +1,50 @@
+@@ title = "Add/Remove Item in Wrong Pocket"
+@@ author = "Adrichu00 (Ported to JPN)"
+@@ exit = null
+@@ filler1 = 0x4040E7FF
+@@ filler2 = 0x00C0FFFF
+@@ filler3 = 0xE7FF46C0
+@@ filler4 = 0xFFFFE000
+
+// pocket: 0 = Key Items, 1 = Poké Balls
+// delete_mode: 0 = add to last slot, 1 = delete first slot
+// Delete mode requires the selected pocket's last slot to be empty.
+// Item IDs:
+// https://bulbapedia.bulbagarden.net/wiki/List_of_items_by_index_number_in_Generation_III
+
+pocket = 0
+item_id = 0x0001
+delete_mode = 1
+
+p = pocket ? 1 : 0
+d = delete_mode ? 1 : 0
+
+target_offset = d ? (p ? 0x0430 : 0x03B8) : (p ? 0x0460 : 0x042C)
+target_base = (target_offset >> 3) & 0xFF
+target_tail = target_offset & 0x07
+
+quantity_delta = d ? (p ? 0x32 : 0x76) : 0x02
+quantity_base = (quantity_delta >> 3) & 0xFF
+quantity_tail = quantity_delta & 0x07
+
+quantity_xor = d ? 0 : 1
+stored_item = d ? 0 : (item_id & 0xFFFF)
+
+item_a = (stored_item & 0xAAAA) ^ 0x0303
+item_b = (stored_item & 0x5555) ^ 0x0303
+item_data = (item_b << 16) | item_a
+
+@@
+
+0x39884629
+0x4A056809
+{0xE0002000 | target_base}
+{0xE0053000 | target_tail}
+{item_data}
+0x0C131809
+0x800A405A
+{0xE0002000 | quantity_base}
+{0x5A0A3000 | quantity_tail}
+{0x405A2300 | quantity_xor}
+0x4040804A
+0x46C04770

--- a/files_frlg/misc/AddItemWrongPocketGRABJP1.txt
+++ b/files_frlg/misc/AddItemWrongPocketGRABJP1.txt
@@ -1,0 +1,50 @@
+@@ title = "Add/Remove Item in Wrong Pocket"
+@@ author = "Adrichu00 (Ported to JPN)"
+@@ exit = null
+@@ filler1 = 0x4040E7FF
+@@ filler2 = 0x00C0FFFF
+@@ filler3 = 0xE7FF46C0
+@@ filler4 = 0xFFFFE000
+
+// pocket: 0 = Key Items, 1 = Poké Balls
+// delete_mode: 0 = add to last slot, 1 = delete first slot
+// Delete mode requires the selected pocket's last slot to be empty.
+// Item IDs:
+// https://bulbapedia.bulbagarden.net/wiki/List_of_items_by_index_number_in_Generation_III
+
+pocket = 0
+item_id = 0x0001
+delete_mode = 1
+
+p = pocket ? 1 : 0
+d = delete_mode ? 1 : 0
+
+target_offset = d ? (p ? 0x0430 : 0x03B8) : (p ? 0x0460 : 0x042C)
+target_base = (target_offset >> 3) & 0xFF
+target_tail = target_offset & 0x07
+
+quantity_delta = d ? (p ? 0x32 : 0x76) : 0x02
+quantity_base = (quantity_delta >> 3) & 0xFF
+quantity_tail = quantity_delta & 0x07
+
+quantity_xor = d ? 0 : 1
+stored_item = d ? 0 : (item_id & 0xFFFF)
+
+item_a = (stored_item & 0xAAAA) ^ 0x0303
+item_b = (stored_item & 0x5555) ^ 0x0303
+item_data = (item_b << 16) | item_a
+
+@@
+
+0x39884629
+0x4A056809
+{0xE0002000 | target_base}
+{0xE0053000 | target_tail}
+{item_data}
+0x0C131809
+0x800A405A
+{0xE0002000 | quantity_base}
+{0x5A0A3000 | quantity_tail}
+{0x405A2300 | quantity_xor}
+0x4040804A
+0x46C04770

--- a/files_frlg/misc/ChangeTrainerGenderGRABJP0.txt
+++ b/files_frlg/misc/ChangeTrainerGenderGRABJP0.txt
@@ -1,0 +1,12 @@
+@@ title = "Change Trainer Gender 1.0 & 1.1"
+@@ author = "Final; (JPN Port)"
+
+@@ filler1 = 0x720AE7FF
+
+gender = 1 // 0 = male, 1 = female
+
+@@
+
+0x39844629
+{((0x2200 | (gender & 1)) << 16) | 0x6809}
+0x47704040

--- a/files_frlg/misc/ChangeTrainerGenderGRABJP1.txt
+++ b/files_frlg/misc/ChangeTrainerGenderGRABJP1.txt
@@ -1,0 +1,12 @@
+@@ title = "Change Trainer Gender 1.0 & 1.1"
+@@ author = "Final; (JPN Port)"
+
+@@ filler1 = 0x720AE7FF
+
+gender = 1 // 0 = male, 1 = female
+
+@@
+
+0x39844629
+{((0x2200 | (gender & 1)) << 16) | 0x6809}
+0x47704040

--- a/files_frlg/misc/CreateTradebackNPCGRABJP0.txt
+++ b/files_frlg/misc/CreateTradebackNPCGRABJP0.txt
@@ -1,0 +1,38 @@
+@@ title = "Create Tradeback NPC"
+@@ author = "Theocatic, Final (JPN Port)"
+@@ exit = null
+@@ filler1 = 0x2227E7FF
+@@ filler2 = 0x0212FFFF
+@@ filler3 = 0xE7FF2302
+@@ filler4 = 0xFFFFE000
+
+; Just like the English version of this code, after executing this code,
+; talk to the Old Gentleman NPC in the Viridian City Pokémon Center
+; when using the default NPC value of 2.
+;
+; The code trades the first Pokémon in the party for an empty Decamark.
+; Talk to the NPC again to receive the original Pokémon back.
+
+NPC = 2 ; NPC values 1, 2, and 3 are usable.
+
+npc_offset = 0x08F0 + ((NPC - 1) * 0x18)
+npc_base = (npc_offset >> 6) & 0xFF
+npc_tail = npc_offset & 0x3F
+
+npc_base_word = ((0x2300 | npc_base) << 16) | 0x6002
+npc_tail_word = ((0x3300 | npc_tail) << 16) | 0x019B
+
+@@
+
+0x4629A0BF
+0x68093988
+0xE0003258
+0x32250052
+0x431A061B
+{npc_base_word}
+{npc_tail_word}
+0xE00018C9
+0x32086008
+0x405B1AA2
+0x40406013
+0x46C04770

--- a/files_frlg/misc/CreateTradebackNPCGRABJP1.txt
+++ b/files_frlg/misc/CreateTradebackNPCGRABJP1.txt
@@ -1,0 +1,38 @@
+@@ title = "Create Tradeback NPC"
+@@ author = "Theocatic, Final (JPN Port)"
+@@ exit = null
+@@ filler1 = 0x2227E7FF
+@@ filler2 = 0x0212FFFF
+@@ filler3 = 0xE7FF2302
+@@ filler4 = 0xFFFFE000
+
+; Just like the English version of this code, after executing this code,
+; talk to the Old Gentleman NPC in the Viridian City Pokémon Center
+; when using the default NPC value of 2.
+;
+; The code trades the first Pokémon in the party for an empty Decamark.
+; Talk to the NPC again to receive the original Pokémon back.
+
+NPC = 2 ; NPC values 1, 2, and 3 are usable.
+
+npc_offset = 0x08F0 + ((NPC - 1) * 0x18)
+npc_base = (npc_offset >> 6) & 0xFF
+npc_tail = npc_offset & 0x3F
+
+npc_base_word = ((0x2300 | npc_base) << 16) | 0x6002
+npc_tail_word = ((0x3300 | npc_tail) << 16) | 0x019B
+
+@@
+
+0x4629A0BF
+0x68093988
+0xE0003258
+0x32250052
+0x431A061B
+{npc_base_word}
+{npc_tail_word}
+0xE00018C9
+0x32086008
+0x405B1AA2
+0x40406013
+0x46C04770

--- a/files_frlg/pkmn/MakeMonShinyGRABJP0.txt
+++ b/files_frlg/pkmn/MakeMonShinyGRABJP0.txt
@@ -1,0 +1,30 @@
+@@ title = "Make any Pokémon shiny"
+@@ author = "Mettrich, final, Adrichu00 and PapaJefe (JPN Port)"
+@@ exit = null
+@@ fill = false
+@@ filler1 = 0x46C0E7FF
+@@ filler2 = 0x46C0FFFF
+@@ filler3 = 0xE7FF46C0
+@@ filler4 = 0xFFFFE000
+
+// Box 1 Slot 1 must contain the target Pokémon.
+
+@@
+
+0x3B80462B
+0x3304681B
+0xE0016818
+0x40486859
+0x0C124602
+0x04124042
+0x60594051
+0xE0013320
+0x68182104
+0x60184050
+0x68183304
+0x60184050
+0xE0013304
+0x40506818
+0x33046018
+0xD1E43901
+0x47704040

--- a/files_frlg/pkmn/MakeMonShinyGRABJP1.txt
+++ b/files_frlg/pkmn/MakeMonShinyGRABJP1.txt
@@ -1,0 +1,30 @@
+@@ title = "Make any Pokémon shiny"
+@@ author = "Mettrich, final, Adrichu00 and PapaJefe (JPN Port)"
+@@ exit = null
+@@ fill = false
+@@ filler1 = 0x46C0E7FF
+@@ filler2 = 0x46C0FFFF
+@@ filler3 = 0xE7FF46C0
+@@ filler4 = 0xFFFFE000
+
+// Box 1 Slot 1 must contain the target Pokémon.
+
+@@
+
+0x3B80462B
+0x3304681B
+0xE0016818
+0x40486859
+0x0C124602
+0x04124042
+0x60594051
+0xE0013320
+0x68182104
+0x60184050
+0x68183304
+0x60184050
+0xE0013304
+0x40506818
+0x33046018
+0xD1E43901
+0x47704040

--- a/files_frlg/rng/SeedChangeAndWarpGRABJP0.txt
+++ b/files_frlg/rng/SeedChangeAndWarpGRABJP0.txt
@@ -1,0 +1,57 @@
+@@ title = "Change PRNG+Teleport 1.0"
+@@ author = "final, Theocatic and Mettrich (ported to JPN)"
+@@ exit = null
+@@ fill = false
+
+// The teleportation will occur as soon as you log off Bill’s PC.
+// This code is best ran in the Route 5 Daycare.
+
+// The map list can be found here:
+// https://pastebin.com/peDhNbEt
+
+map_id = 0x0
+
+// `warp` determines which warp point you will teleport to.
+
+warp = 0
+
+// Input the desired RNG state here.
+
+seed = 0x0
+
+// Teleport script:
+//
+// 39 YY XX WW 00 00 00 00
+// warp 0xYY 0xXX 0xWW
+// FF @ illegal command, terminates script execution
+
+script = ((warp & 0xFF) << 24) | ((map_id & 0xFFFF) << 8) | 0x39
+
+@@
+
+0x4A114620 ; mov r0,r4 | ldr r2,[pc,#0x44]
+0x405A4B11 ; ldr r3,[pc,#0x44] | eor r2,r3
+0x490D23FF ; mov r3,#0xFF | ldr r1,[pc,#0x34]
+0xE000011B ; lsl r3,r3,#4 | b #0x4
+0x18C0FF00 ; FF00 | add r0,r0,r3
+0x60026088 ; str r0,[r1,#0x8] | str r2,[r0]
+0x28FF2200 ; mov r2,#0 | cmp r0,#0xFF
+0x43D26042 ; str r2,[r0,#0x4] | mvn r2,r2
+0xFF00E000 ; b #0x4 | FF00
+0x4B0B7202 ; strb r2,[r0,#0x8] | ldr r3,[pc,#0x2C]
+0x4A0E490C ; ldr r1,[pc,#0x30] | ldr r2,[pc,#0x38]
+0x405128FF ; cmp r0,#0xFF | eor r1,r2
+0xE0006019 ; str r1,[r3] | b #0x4
+0x2000FF00 ; FF00 | mov r0,#0
+0x00004770 ; bx r14 | 0000
+0x00FF0000
+0x03000EB0
+0xFF000000
+{script & 0xAAAAAAAA}
+{script & 0x55555555}
+0x000000FF
+0x03005040
+0x0000FF00
+{(seed & 0xAAAAAAAA) ^ 0x03030303}
+0x00FF0000
+{(seed & 0x55555555) ^ 0x03030303}

--- a/files_frlg/rng/SeedChangeAndWarpGRABJP1.txt
+++ b/files_frlg/rng/SeedChangeAndWarpGRABJP1.txt
@@ -1,0 +1,57 @@
+@@ title = "Change PRNG+Teleport 1.1"
+@@ author = "final, Theocatic and Mettrich (ported to JPN)"
+@@ exit = null
+@@ fill = false
+
+// The teleportation will occur as soon as you log off Bill’s PC.
+// This code is best ran in the Route 5 Daycare.
+
+// The map list can be found here:
+// https://pastebin.com/peDhNbEt
+
+map_id = 0
+
+// `warp` determines which warp point you will teleport to. Use warp 3 for Zapdos
+
+warp = 0
+
+// Input the desired RNG state here.
+
+seed = 0
+
+// Teleport script:
+//
+// 39 YY XX WW 00 00 00 00
+// warp 0xYY 0xXX 0xWW
+// FF @ illegal command, terminates script execution
+
+script = ((warp & 0xFF) << 24) | ((map_id & 0xFFFF) << 8) | 0x39
+
+@@
+
+0x4A114620 ; mov r0,r4 | ldr r2,[pc,#0x44]
+0x405A4B11 ; ldr r3,[pc,#0x44] | eor r2,r3
+0x490D23FF ; mov r3,#0xFF | ldr r1,[pc,#0x34]
+0xE000011B ; lsl r3,r3,#4 | b #0x4
+0x18C0FF00 ; FF00 | add r0,r0,r3
+0x60026088 ; str r0,[r1,#0x8] | str r2,[r0]
+0x28FF2200 ; mov r2,#0 | cmp r0,#0xFF
+0x43D26042 ; str r2,[r0,#0x4] | mvn r2,r2
+0xFF00E000 ; b #0x4 | FF00
+0x4B0B7202 ; strb r2,[r0,#0x8] | ldr r3,[pc,#0x2C]
+0x4A0E490C ; ldr r1,[pc,#0x30] | ldr r2,[pc,#0x38]
+0x405128FF ; cmp r0,#0xFF | eor r1,r2
+0xE0006219 ; str r1,[r3,#0x20] | b #0x4
+0x2000FF00 ; FF00 | mov r0,#0
+0x00004770 ; bx r14 | 0000
+0x00FF0000
+0x03000EB0
+0xFF000000
+{script & 0xAAAAAAAA}
+{script & 0x55555555}
+0x000000FF
+0x03004F80
+0x0000FF00
+{(seed & 0xAAAAAAAA) ^ 0x03030303}
+0x00FF0000
+{(seed & 0x55555555) ^ 0x03030303}

--- a/files_frlg/rng/tidsidGRABJP0.txt
+++ b/files_frlg/rng/tidsidGRABJP0.txt
@@ -1,0 +1,23 @@
+@@ title = "Change TID SID"
+@@ author = "Shao & Papa Jefe (ported to JPN)"
+@@ exit = null
+@@ filler1 = 0x4B07E7FF
+@@ filler2 = 0x814AFFFF
+@@ filler3 = 0xE7FF818A
+
+tid = 0
+sid = 0
+
+trainer_ids = ((sid & 0xFFFF) << 16) | (tid & 0xFFFF)
+trainer_low = trainer_ids & 0x7F7F7F7F
+trainer_high = trainer_ids & 0x80808080
+
+@@
+
+0x39844629 ; mov r1,r5 | sub r1,#0x84
+0x4A076809 ; ldr r1,[r1] | ldr r2,[pc,#0x1C]
+0xE000431A ; orrs r2,r3 | b to filler2 TID store
+0x46C00C12 ; lsrs r2,r2,#16 | nop
+0x47704040 ; eors r0,r0 | bx lr
+{trainer_low}
+{trainer_high}

--- a/files_frlg/rng/tidsidGRABJP1.txt
+++ b/files_frlg/rng/tidsidGRABJP1.txt
@@ -1,0 +1,23 @@
+@@ title = "Change TID SID"
+@@ author = "Shao & Papa Jefe (ported to JPN)"
+@@ exit = null
+@@ filler1 = 0x4B07E7FF
+@@ filler2 = 0x814AFFFF
+@@ filler3 = 0xE7FF818A
+
+tid = 0
+sid = 0
+
+trainer_ids = ((sid & 0xFFFF) << 16) | (tid & 0xFFFF)
+trainer_low = trainer_ids & 0x7F7F7F7F
+trainer_high = trainer_ids & 0x80808080
+
+@@
+
+0x39844629 ; mov r1,r5 | sub r1,#0x84
+0x4A076809 ; ldr r1,[r1] | ldr r2,[pc,#0x1C]
+0xE000431A ; orrs r2,r3 | b to filler2 TID store
+0x46C00C12 ; lsrs r2,r2,#16 | nop
+0x47704040 ; eors r0,r0 | bx lr
+{trainer_low}
+{trainer_high}


### PR DESCRIPTION
Hey, I recently ported some codes for Japanese Grab Ace using 0xFFC9. These were ported from existing English FRLG codes to help bring the Japanese versions closer to the code coverage currently available for other languages.

I separated the codes for revisions 1.0 and 1.1, and tested all codes on mgba with bios.

These additions are separate from the existing Japanese move ACE and bootstrapped codes.

## Codes added

- Make any Pokémon shiny
- Add/remove an item in the wrong pocket
- Change trainer gender
- Create the tradeback NPC
- Change TID and SID
- Change PRNG seed and teleport

I also updated list.json so that the new files are already registered in the CodeGenerator catalog. This should make the PR easier to review and merge (which I forgot to do when I sent a pull request earlier).

I added a new PRNG seed and teleport catalog entry under rng, since the only existing ones were bootstrapped and move ace, and this code falls under neither since you can do it without a box 14 exit or glitch move. All other codes fell under already existing categories, so I added them accordingly.